### PR TITLE
Fix "Git Plus: Add (all)" without open editor

### DIFF
--- a/lib/git-add.coffee
+++ b/lib/git-add.coffee
@@ -4,19 +4,22 @@ StatusView = require './status-view'
 # if all param true, then 'git add .'
 gitAdd = (all=false)->
   dir = atom.project.getRepo().getWorkingDirectory()
-  currentFile = atom.workspace.getActiveEditor().getPath()
+  currentFile = atom.workspace.getActiveEditor()?.getPath()
   toStage = if all then '.' else currentFile
-  new BufferedProcess({
-    command: 'git'
-    args: ['add', '--all', toStage]
-    options:
-      cwd: dir
-    stderr: (data) ->
-      new StatusView(type: 'alert', message: data.toString())
-    exit: (data) ->
-      file = if toStage is '.' then 'all files' else prettify(dir, toStage)
-      new StatusView(type: 'success', message: "Added #{file}")
-  })
+  if (toStage?)
+    new BufferedProcess({
+      command: 'git'
+      args: ['add', '--all', toStage]
+      options:
+        cwd: dir
+      stderr: (data) ->
+        new StatusView(type: 'alert', message: data.toString())
+      exit: (data) ->
+        file = if toStage is '.' then 'all files' else prettify(dir, toStage)
+        new StatusView(type: 'success', message: "Added #{file}")
+    })
+  else
+    new StatusView(type: 'alert', message: "I don't know which file(s) to add!")
 
 # only show filepaths inside the project
 prettify = (dir, file) ->


### PR DESCRIPTION
In the context, it would give a type error because `atom.workspace.getActiveEditor()` was `undefined`.

This type error did prevent "Add all" from working; "Add" could not have done much, but now instead of failing with a TypeError it returns a proper error message.
