### PR TITLE
Fix pathspec error on current branch checkout

### DIFF
--- a/lib/branch-list-view.coffee
+++ b/lib/branch-list-view.coffee
@@ -33,7 +33,7 @@ class ListView extends SelectListView
 
 
   confirmed: ({name}) ->
-    @checkout name
+    @checkout name.match(/\*?(.*)/)[1]
     @cancel()
 
   checkout: (branch) ->


### PR DESCRIPTION
Try to checkout the current branch. You check for the `*` starting the current branch name but fail to remove it from the branch name passed to the git process.

![error pathspec](https://cloud.githubusercontent.com/assets/5219415/3193910/af36fc62-ecf7-11e3-84cc-eaf932db16c6.png)
