### PR TITLE
Add activation events: log, diff, diff-all

### DIFF
--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -3,6 +3,9 @@ GitCommit = require './models/git-commit'
 GitAddAndCommit = require './models/git-add-and-commit'
 GitAddAllAndCommit = require './models/git-add-all-and-commit'
 GitStatus = require './models/git-status'
+GitLog = require './models/git-log'
+GitDiff = require './models/git-diff'
+GitDiffAll = require './models/git-diff-all'
 
 GitPaletteView = require './views/git-palette-view'
 
@@ -23,3 +26,6 @@ module.exports =
     atom.workspaceView.command 'git-plus:add-and-commit', -> GitAddAndCommit()
     atom.workspaceView.command 'git-plus:add-all-and-commit', -> GitAddAllAndCommit()
     atom.workspaceView.command 'git-plus:status', -> GitStatus()
+    atom.workspaceView.command 'git-plus:log', -> GitLog()
+    atom.workspaceView.command 'git-plus:diff', -> GitDiff()
+    atom.workspaceView.command 'git-plus:diff-all', -> GitDiffAll()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "git-plus:commit",
     "git-plus:add-and-commit",
     "git-plus:add-all-and-commit",
-    "git-plus:status"
+    "git-plus:status",
+    "git-plus:log",
+    "git-plus:diff",
+    "git-plus:diff-all"
   ],
   "repository": "https://github.com/akonwi/git-plus",
   "license": "MIT",


### PR DESCRIPTION
I updated this package, then I can not call `git-plus:diff`. I know it can call by `git-plus:menu`, but I was added my keymap like

```
'ctrl-g d': 'git-plus:diff'
```

So I want to call `git-plus:diff` (and some other commands) by command palette. Is there a way to accomplish this to others?

thanks.
