### PR TITLE
Hide keybindings from stock command palette

### DIFF
--- a/lib/git-plus-commands.coffee
+++ b/lib/git-plus-commands.coffee
@@ -1,29 +1,29 @@
 git = require './git'
 
 getCommands = ->
-  GitCommit = require './models/git-commit'
-  GitAdd = require './models/git-add'
-  GitBranch = require './models/git-branch'
-  GitPull = require './models/git-pull'
-  GitDiff = require './models/git-diff'
-  GitDiffAll = require './models/git-diff-all'
-  GitPush = require './models/git-push'
-  GitFetch = require './models/git-fetch'
+  GitAdd                 = require './models/git-add'
+  GitAddAllAndCommit     = require './models/git-add-all-and-commit'
+  GitAddAndCommit        = require './models/git-add-and-commit'
+  GitBranch              = require './models/git-branch'
+  GitCheckoutAllFiles    = require './models/git-checkout-all-files'
   GitCheckoutCurrentFile = require './models/git-checkout-current-file'
-  GitCheckoutAllFiles = require './models/git-checkout-all-files'
-  GitAddAndCommit = require './models/git-add-and-commit'
-  GitCommitAmend = require './models/git-commit-amend'
-  GitAddAllAndCommit = require './models/git-add-all-and-commit'
-  GitRemove = require './models/git-remove'
-  GitLog = require './models/git-log'
-  GitShow = require './models/git-show'
-  GitTags = require './models/git-tags'
-  GitInit = require './models/git-init'
-  GitStageFiles = require './models/git-stage-files'
-  GitUnstageFiles = require './models/git-unstage-files'
-  GitStageHunk = require './models/git-stage-hunk'
-  GitCherryPick = require './models/git-cherry-pick'
-  GitStatus = require './models/git-status'
+  GitCherryPick          = require './models/git-cherry-pick'
+  GitCommit              = require './models/git-commit'
+  GitCommitAmend         = require './models/git-commit-amend'
+  GitDiff                = require './models/git-diff'
+  GitDiffAll             = require './models/git-diff-all'
+  GitFetch               = require './models/git-fetch'
+  GitInit                = require './models/git-init'
+  GitLog                 = require './models/git-log'
+  GitPull                = require './models/git-pull'
+  GitPush                = require './models/git-push'
+  GitRemove              = require './models/git-remove'
+  GitShow                = require './models/git-show'
+  GitStageFiles          = require './models/git-stage-files'
+  GitStageHunk           = require './models/git-stage-hunk'
+  GitStatus              = require './models/git-status'
+  GitTags                = require './models/git-tags'
+  GitUnstageFiles        = require './models/git-unstage-files'
 
   commands = []
   if atom.project.getRepo()?
@@ -34,28 +34,28 @@ getCommands = ->
       commands.push ['git-plus:remove-current-file', 'Remove Current File', -> GitRemove()]
       commands.push ['git-plus:checkout-current-file', 'Checkout Current File', -> GitCheckoutCurrentFile()]
 
-    commands.push ['git-plus:add-and-commit', 'Add And Commit', -> GitAddAndCommit()]
+    commands.push ['git-plus:add-all', 'Add All', -> GitAdd(true)]
     commands.push ['git-plus:add-all-and-commit', 'Add All And Commit', -> GitAddAllAndCommit()]
+    commands.push ['git-plus:add-and-commit', 'Add And Commit', -> GitAddAndCommit()]
+    commands.push ['git-plus:checkout', 'Checkout', -> GitBranch.gitBranches()]
+    commands.push ['git-plus:checkout-all-files', 'Checkout All Files', -> GitCheckoutAllFiles()]
+    commands.push ['git-plus:cherry-pick', 'Cherry-Pick', -> GitCherryPick()]
     commands.push ['git-plus:commit', 'Commit', -> new GitCommit]
     commands.push ['git-plus:commit-amend', 'Commit Amend', -> GitCommitAmend()]
-    commands.push ['git-plus:add-all', 'Add All', -> GitAdd(true)]
-    commands.push ['git-plus:checkout-all-files', 'Checkout All Files', -> GitCheckoutAllFiles()]
     commands.push ['git-plus:diff', 'Diff', -> GitDiff()]
     commands.push ['git-plus:diff-all', 'Diff All', -> GitDiffAll()]
-    commands.push ['git-plus:checkout', 'Checkout', -> GitBranch.gitBranches()]
+    commands.push ['git-plus:fetch', 'Fetch', -> GitFetch()]
+    commands.push ['git-plus:log', 'Log', -> GitLog()]
     commands.push ['git-plus:new-branch', 'Checkout New Branch', -> GitBranch.newBranch()]
     commands.push ['git-plus:pull', 'Pull', -> GitPull()]
     commands.push ['git-plus:push', 'Push', -> GitPush()]
-    commands.push ['git-plus:fetch', 'Fetch', -> GitFetch()]
     commands.push ['git-plus:remove', 'Remove', -> GitRemove(true)]
-    commands.push ['git-plus:log', 'Log', -> GitLog()]
     commands.push ['git-plus:show', 'Show', -> GitShow()]
-    commands.push ['git-plus:tags', 'Tags', -> GitTags()]
     commands.push ['git-plus:stage-files', 'Stage Files', -> GitStageFiles()]
-    commands.push ['git-plus:unstage-files', 'Unstage Files', -> GitUnstageFiles()]
     commands.push ['git-plus:stage-hunk', 'Stage Hunk', -> GitStageHunk()]
-    commands.push ['git-plus:cherry-pick', 'Cherry-Pick', -> GitCherryPick()]
     commands.push ['git-plus:status', 'Status', -> GitStatus()]
+    commands.push ['git-plus:tags', 'Tags', -> GitTags()]
+    commands.push ['git-plus:unstage-files', 'Unstage Files', -> GitUnstageFiles()]
   else
     commands.push ['git-plus:init', 'Init', -> GitInit()]
 

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -1,13 +1,4 @@
-GitAdd = require './models/git-add'
-GitCommit = require './models/git-commit'
-GitAddAndCommit = require './models/git-add-and-commit'
-GitAddAllAndCommit = require './models/git-add-all-and-commit'
-GitStatus = require './models/git-status'
-GitLog = require './models/git-log'
-GitDiff = require './models/git-diff'
-GitDiffAll = require './models/git-diff-all'
-
-GitPaletteView = require './views/git-palette-view'
+{$} = require 'atom'
 
 module.exports =
   configDefaults:
@@ -19,14 +10,24 @@ module.exports =
     gitPath: 'git'
 
   activate: (state) ->
+    GitAdd             = require './models/git-add'
+    GitAddAllAndCommit = require './models/git-add-all-and-commit'
+    GitAddAndCommit    = require './models/git-add-and-commit'
+    GitCommit          = require './models/git-commit'
+    GitDiff            = require './models/git-diff'
+    GitDiffAll         = require './models/git-diff-all'
+    GitLog             = require './models/git-log'
+    GitPaletteView     = require './views/git-palette-view'
+    GitStatus          = require './models/git-status'
+
     atom.workspaceView.command 'git-plus:menu', -> new GitPaletteView()
 
     # Only keybindings get here as well!
-    atom.workspaceView.command 'git-plus:add', -> GitAdd()
-    atom.workspaceView.command 'git-plus:commit', -> new GitCommit
-    atom.workspaceView.command 'git-plus:add-and-commit', -> GitAddAndCommit()
-    atom.workspaceView.command 'git-plus:add-all-and-commit', -> GitAddAllAndCommit()
-    atom.workspaceView.command 'git-plus:status', -> GitStatus()
-    atom.workspaceView.command 'git-plus:log', -> GitLog()
-    atom.workspaceView.command 'git-plus:diff', -> GitDiff()
-    atom.workspaceView.command 'git-plus:diff-all', -> GitDiffAll()
+    $(window).on 'git-plus:add',                -> GitAdd()
+    $(window).on 'git-plus:add-all-and-commit', -> GitAddAllAndCommit()
+    $(window).on 'git-plus:add-and-commit',     -> GitAddAndCommit()
+    $(window).on 'git-plus:commit',             -> new GitCommit()
+    $(window).on 'git-plus:diff',               -> GitDiff()
+    $(window).on 'git-plus:diff-all',           -> GitDiffAll()
+    $(window).on 'git-plus:log',                -> GitLog()
+    $(window).on 'git-plus:status',             -> GitStatus()

--- a/lib/models/git-commit.coffee
+++ b/lib/models/git-commit.coffee
@@ -24,13 +24,11 @@ class GitCommit extends Model
       atom.project.getRepo()?.getWorkingDirectory() ? atom.project.getPath()
 
   filePath: -> path.join @dir(), @file()
-
   currentPane: atom.workspace.getActivePane()
 
   constructor: (@amend='') ->
     super
     return if @assignId() isnt 1
-
     git.stagedFiles (files) =>
       if @amend isnt '' or files.length >= 1
         git.cmd
@@ -39,7 +37,6 @@ class GitCommit extends Model
       else
         @cleanup()
         new StatusView(type: 'error', message: 'Nothing to commit.')
-
 
   # FIXME?: maybe I shouldn't use the COMMIT file in .git/
   prepFile: (status) ->

--- a/package.json
+++ b/package.json
@@ -4,15 +4,6 @@
   "version": "3.4.2",
   "description": "Do git things without the terminal",
   "activationEvents": [
-    "git-plus:menu",
-    "git-plus:add",
-    "git-plus:commit",
-    "git-plus:add-and-commit",
-    "git-plus:add-all-and-commit",
-    "git-plus:status",
-    "git-plus:log",
-    "git-plus:diff",
-    "git-plus:diff-all"
   ],
   "repository": "https://github.com/akonwi/git-plus",
   "license": "MIT",


### PR DESCRIPTION
This hides everything except the `Git Plus: Menu` command from the stock palette. There is a performance impact, but I think average package load times of 40ms are acceptable to avoid the confusion.

In the long term the stock `command-palette` needs a way to hide commands.

& some general code formatting to make reading it easier.
