### PR TITLE
Fix: git.relativize to working repository

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -116,9 +116,9 @@ dir = ->
   else
     atom.project.getRepo()?.getWorkingDirectory() ? atom.project.getPath()
 
-# returns filepath relativized for either a submodule or a project
+# returns filepath relativized for either a submodule, repository or a project
 relativize = (path) ->
-  getSubmodule(path)?.relativize(path) ? atom.project.relativize(path)
+  getSubmodule(path)?.relativize(path) ? atom.project.getRepo()?.relativize(path) ? atom.project.relativize(path)
 
 # returns submodule for given file or undefined
 getSubmodule = (path) ->


### PR DESCRIPTION
The problem I fixed inside `git.relativize()` occurs when user opens a
project folder, which is not directly a root folder, but rather a
subfolder inside repository.
I have left `atom.project.relativize` there as a third option, it might be redundant because
the user will already have a repository if they wish to use git.
