### PR TITLE
Show `git diff --cached` results on commit window

### DIFF
--- a/lib/models/git-commit.coffee
+++ b/lib/models/git-commit.coffee
@@ -64,7 +64,7 @@ class GitCommit extends Model
     git.stagedFiles (files) =>
       if @amend isnt '' or files.length >= 1
         git.cmd
-          args: ['status'],
+          args: ['status', '-v'],
           stdout: (data) => @prepFile data
       else
         @cleanup()


### PR DESCRIPTION
Shows changes made with the commit.
This can help to go through changes one last time before the commit

Check this [Screenshot](https://www.dropbox.com/s/6466omiod9neb0k/Screenshot%202014-07-28%2005.54.40.png) for a quick demo.
