### PR TITLE
Fix for object names being shortened unnecessarily.

### DIFF
--- a/lib/models/git-show.coffee
+++ b/lib/models/git-show.coffee
@@ -40,8 +40,9 @@ class InputView extends View
     atom.workspaceView.append this
     @objectHash.focus()
     @objectHash.on 'core:confirm', =>
-      object = $(this).text().slice(2)
-      callback object
+      text = $(this).text().split(' ')
+      name = if text.length is 2 then text[1] else text[0]
+      callback text
       @detach()
 
 module.exports = (objectHash, file) ->


### PR DESCRIPTION
Fix for same issue as #101 but with Show command.

BTW As I have freshly installed Atom and Git Plus, I would recommend checking, whether some other plugin is adding that "1 " to the DOM.
