### PR TITLE
Update git-plus.cson

### DIFF
--- a/menus/git-plus.cson
+++ b/menus/git-plus.cson
@@ -7,7 +7,7 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'git-plus'
+      'label': 'Git Plus'
       'submenu': [
         { 'label': 'Add', 'command': 'git-plus:add' }
         { 'label': 'Add All', 'command': 'git-plus:add-all' }


### PR DESCRIPTION
Most atom packages seem to be using human readable labels rather than hyphenated labels.  Just a "tick" on my part! :)
