### PR TITLE
Provide git-plus menu in all projects

### DIFF
--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -63,8 +63,9 @@ module.exports =
     GitRun                 = require './models/git-run'
     GitMerge               = require './models/git-merge'
 
+    atom.commands.add 'atom-workspace', 'git-plus:menu', -> new GitPaletteView()
+
     if not atom.project.getRepo()?
-      atom.commands.add 'atom-workspace', 'git-plus:menu', -> new GitPaletteView()
       atom.commands.add 'atom-workspace', 'git-plus:init', -> GitInit()
     else
       git.refresh()


### PR DESCRIPTION
The git-plus menu was only available when the current project was not a git repo as of 555a0d2ae91978ce3c6de962b33b7f406ccc158f. The menu is now always available.