### PR TITLE
Remove remaining deprecate workspaceView calls

### DIFF
--- a/lib/git-plus-commands.coffee
+++ b/lib/git-plus-commands.coffee
@@ -28,6 +28,7 @@ getCommands = ->
   GitStatus              = require './models/git-status'
   GitTags                = require './models/git-tags'
   GitUnstageFiles        = require './models/git-unstage-files'
+  GitRun                 = require './models/git-run'
   GitMerge               = require './models/git-merge'
 
   commands = []
@@ -68,6 +69,7 @@ getCommands = ->
     commands.push ['git-plus:status', 'Status', -> GitStatus()]
     commands.push ['git-plus:tags', 'Tags', -> GitTags()]
     commands.push ['git-plus:unstage-files', 'Unstage Files', -> GitUnstageFiles()]
+    commands.push ['git-plus:run', 'Run', -> GitRun()]
     commands.push ['git-plus:merge', 'Merge', -> GitMerge()]
 
   commands

--- a/lib/models/git-remove.coffee
+++ b/lib/models/git-remove.coffee
@@ -7,7 +7,7 @@ gitRemove = (showSelector=false) ->
 
   if currentFile? and not showSelector
     if window.confirm 'Are you sure?'
-      atom.workspaceView.getActiveView().remove()
+      atom.workspace.getActivePaneItem().destroy()
       git.cmd
         args: ['rm', '-f', '--ignore-unmatch', currentFile],
         stdout: (data) ->  new StatusView(type: 'success', message: "Removed #{prettify data}")

--- a/lib/models/git-run.coffee
+++ b/lib/models/git-run.coffee
@@ -1,21 +1,22 @@
-{$, EditorView, View} = require 'atom'
+{$, TextEditorView, View} = require 'atom-space-pen-views'
 
 git = require '../git'
 StatusView = require '../views/status-view'
 
 class InputView extends View
   @content: ->
-    @div class: 'overlay from-top', =>
-      @subview 'commandEditor', new EditorView(mini: true, placeHolderText: 'Git command and arguments')
+    @div =>
+      @subview 'commandEditor', new TextEditorView(mini: true, placeHolderText: 'Git command and arguments')
 
   initialize: ->
     @currentPane = atom.workspace.getActivePane()
-    atom.workspaceView.append this
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
     @commandEditor.focus()
-    @on 'core:cancel', => @detach()
+    @on 'core:cancel', => @panel.destroy()
     @commandEditor.on 'core:confirm', =>
-      @detach()
-      args = $(this).text().split(' ')
+      @panel.destroy()
+      args = @commandEditor.getText().split(' ')
       if args[0] is 1 then args.shift()
       git.cmd
         args: args

--- a/lib/models/git-show.coffee
+++ b/lib/models/git-show.coffee
@@ -2,7 +2,7 @@ Os = require 'os'
 Path = require 'path'
 fs = require 'fs-plus'
 
-{$, EditorView, View} = require 'atom'
+{$, TextEditorView, View} = require 'atom-space-pen-views'
 
 git = require '../git'
 ListView = require '../views/branch-list-view'
@@ -33,19 +33,23 @@ showFile = ->
 
 class InputView extends View
   @content: ->
-    @div class: 'overlay from-top', =>
-      @subview 'objectHash', new EditorView(mini: true, placeholderText: 'Commit hash to show')
+    @div =>
+      @subview 'objectHash', new TextEditorView(mini: true, placeholderText: 'Commit hash to show')
 
   initialize: (callback) ->
-    atom.workspaceView.append this
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
     @on 'core:cancel', =>
-      @detach()
+      @destroy()
     @objectHash.focus()
     @objectHash.on 'core:confirm', =>
-      text = $(this).text().split(' ')
+      text = @objectHash.getModel().getText().split(' ')
       name = if text.length is 2 then text[1] else text[0]
       callback text
-      @detach()
+      @destroy()
+
+  destroy: ->
+    @panel.destroy()
 
 module.exports = (objectHash, file) ->
   if not objectHash?

--- a/lib/views/cherry-pick-select-commits-view.coffee
+++ b/lib/views/cherry-pick-select-commits-view.coffee
@@ -1,4 +1,4 @@
-{$, $$, EditorView} = require 'atom'
+{$, $$} = require 'atom-space-pen-views'
 
 git = require '../git'
 OutputView = require './output-view'
@@ -10,13 +10,12 @@ class CherryPickSelectCommits extends SelectListMultipleView
 
   initialize: (data) ->
     super
-    @addClass('overlay from-top')
+    @show()
     @setItems(
       for item in data
         item = item.split('\n')
         {hash: item[0], author: item[1], time: item[2], subject: item[3]}
     )
-    atom.workspaceView.append(this)
     @focusFilterEditor()
 
   getFilterKey: ->
@@ -34,6 +33,17 @@ class CherryPickSelectCommits extends SelectListMultipleView
     @on 'click', 'button', ({target}) =>
       @complete() if $(target).hasClass('btn-pick-button')
       @cancel() if $(target).hasClass('btn-cancel-button')
+
+  show: ->
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
+
+    @storeFocusedElement()
+
+  cancelled: -> @hide()
+
+  hide: ->
+    @panel?.hide()
 
   viewForItem: (item, matchedStr) ->
     $$ ->

--- a/lib/views/remove-list-view.coffee
+++ b/lib/views/remove-list-view.coffee
@@ -51,7 +51,8 @@ class SelectStageFilesView extends SelectListMultipleView
 
     currentFile = git.relativize atom.workspace.getActiveEditor()?.getPath()
 
-    atom.workspaceView.getActiveView().remove() if currentFile in files
+    editor = atom.workspace.getActiveTextEditor()
+    atom.views.getView(editor).remove() if currentFile in files
     git.cmd
       args: ['rm', '-f'].concat(files),
       stdout: (data) ->  new StatusView(type: 'success', message: "Removed #{prettify data}")

--- a/lib/views/remove-list-view.coffee
+++ b/lib/views/remove-list-view.coffee
@@ -1,4 +1,4 @@
-{$, $$, EditorView} = require 'atom'
+{$, $$, EditorView} = require 'atom-space-pen-views'
 
 git = require '../git'
 OutputView = require './output-view'
@@ -10,10 +10,9 @@ class SelectStageFilesView extends SelectListMultipleView
 
   initialize: (items) ->
     super
-    @addClass('overlay from-top')
+    @show()
 
     @setItems items
-    atom.workspaceView.append(this)
     @focusFilterEditor()
 
   addButtons: ->
@@ -29,6 +28,17 @@ class SelectStageFilesView extends SelectListMultipleView
       if $(target).hasClass('btn-remove-button')
         @complete() if window.confirm 'Are you sure?'
       @cancel() if $(target).hasClass('btn-cancel-button')
+
+  show: ->
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
+
+    @storeFocusedElement()
+
+  cancelled: -> @hide()
+
+  hide: ->
+    @panel?.hide()
 
   viewForItem: (item, matchedStr) ->
     $$ ->

--- a/lib/views/select-list-multiple-view.coffee
+++ b/lib/views/select-list-multiple-view.coffee
@@ -1,5 +1,5 @@
 fuzzyFilter = require('../models/fuzzy').filter
-{$, $$, View, SelectListView} = require 'atom'
+{$, $$, View, SelectListView} = require 'atom-space-pen-views'
 
 # Public: Provides a view that renders a list of items with an editor that
 # filters the items. Enables you to select multiple items at once.

--- a/lib/views/select-stage-files-view.coffee
+++ b/lib/views/select-stage-files-view.coffee
@@ -1,4 +1,4 @@
-{$, $$, EditorView} = require 'atom'
+{$, $$} = require 'atom-space-pen-views'
 
 git = require '../git'
 OutputView = require './output-view'
@@ -10,10 +10,9 @@ class SelectStageFilesView extends SelectListMultipleView
 
   initialize: (items) ->
     super
-    @addClass('overlay from-top')
+    @show()
 
     @setItems items
-    atom.workspaceView.append(this)
     @focusFilterEditor()
 
   getFilterKey: ->
@@ -31,6 +30,17 @@ class SelectStageFilesView extends SelectListMultipleView
     @on 'click', 'button', ({target}) =>
       @complete() if $(target).hasClass('btn-stage-button')
       @cancel() if $(target).hasClass('btn-cancel-button')
+
+  show: ->
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
+
+    @storeFocusedElement()
+
+  cancelled: -> @hide()
+
+  hide: ->
+    @panel?.hide()
 
   viewForItem: (item, matchedStr) ->
     $$ ->

--- a/lib/views/select-stage-hunks-view.coffee
+++ b/lib/views/select-stage-hunks-view.coffee
@@ -1,5 +1,5 @@
 fs = require 'fs-plus'
-{$, $$, EditorView} = require 'atom'
+{$, $$} = require 'atom-space-pen-views'
 
 git = require '../git'
 OutputView = require './output-view'
@@ -14,10 +14,9 @@ class SelectStageHunks extends SelectListMultipleView
     @patch_header = data[0]
     return @completed @_generateObjects(data[1..]) if data.length is 2
 
-    @addClass('overlay from-top')
+    @show()
     @setItems @_generateObjects(data[1..])
 
-    atom.workspaceView.append(this)
     @focusFilterEditor()
 
   getFilterKey: ->
@@ -35,6 +34,17 @@ class SelectStageHunks extends SelectListMultipleView
     @on 'click', 'button', ({target}) =>
       @complete() if $(target).hasClass('btn-stage-button')
       @cancel() if $(target).hasClass('btn-cancel-button')
+
+  show: ->
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
+
+    @storeFocusedElement()
+
+  cancelled: -> @hide()
+
+  hide: ->
+    @panel?.hide()
 
   viewForItem: (item, matchedStr) ->
     viewItem = $$ ->

--- a/lib/views/select-unstage-files-view.coffee
+++ b/lib/views/select-unstage-files-view.coffee
@@ -1,4 +1,4 @@
-{$, $$, EditorView} = require 'atom'
+{$, $$} = require 'atom-space-pen-views'
 
 git = require '../git'
 OutputView = require './output-view'
@@ -10,10 +10,9 @@ class SelectStageFilesView extends SelectListMultipleView
 
   initialize: (items) ->
     super
-    @addClass('overlay from-top')
+    @show()
 
     @setItems items
-    atom.workspaceView.append(this)
     @focusFilterEditor()
 
   getFilterKey: ->
@@ -31,6 +30,17 @@ class SelectStageFilesView extends SelectListMultipleView
     @on 'click', 'button', ({target}) =>
       @complete() if $(target).hasClass('btn-unstage-button')
       @cancel() if $(target).hasClass('btn-cancel-button')
+
+  show: ->
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
+
+    @storeFocusedElement()
+
+  cancelled: -> @hide()
+
+  hide: ->
+    @panel?.hide()
 
   viewForItem: (item, matchedStr) ->
     $$ ->

--- a/lib/views/tag-create-view.coffee
+++ b/lib/views/tag-create-view.coffee
@@ -27,6 +27,7 @@ class TagCreateView extends View
     @panel.show()
     @tagName.focus()
     @on 'core:cancel', => @destroy()
+    @on 'core:confirm', => @createTag()
 
   createTag: ->
     tag = name: @tagName.getModel().getText(), message: @tagMessage.getModel().getText()

--- a/lib/views/tag-create-view.coffee
+++ b/lib/views/tag-create-view.coffee
@@ -2,7 +2,8 @@ Os = require 'os'
 Path = require 'path'
 fs = require 'fs-plus'
 
-{$, BufferedProcess, EditorView, View} = require 'atom'
+{BufferedProcess} = require 'atom'
+{$, TextEditorView, View} = require 'atom-space-pen-views'
 StatusView = require './status-view'
 git = require '../git'
 
@@ -12,9 +13,9 @@ class TagCreateView extends View
   @content: ->
     @div class: 'overlay from-top', =>
       @div class: 'block', =>
-        @subview 'tagName', new EditorView(mini: true, placeholderText: 'Tag')
+        @subview 'tagName', new TextEditorView(mini: true, placeholderText: 'Tag')
       @div class: 'block', =>
-        @subview 'tagMessage', new EditorView(mini: true, placeholderText: 'Annotation message')
+        @subview 'tagMessage', new TextEditorView(mini: true, placeholderText: 'Annotation message')
       @div class: 'block', =>
         @span class: 'pull-left', =>
           @button class: 'btn btn-success inline-block-tight gp-confirm-button', click: 'createTag', 'Create Tag'
@@ -22,12 +23,13 @@ class TagCreateView extends View
           @button class: 'btn btn-error inline-block-tight gp-cancel-button', click: 'abort', 'Cancel'
 
   initialize: ->
-    atom.workspaceView.append this
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
     @tagName.focus()
-    @on 'core:cancel', => @abort()
+    @on 'core:cancel', => @destroy()
 
   createTag: ->
-    tag = name: @tagName.text().slice(2), message: @tagMessage.text().slice(2)
+    tag = name: @tagName.getModel().getText(), message: @tagMessage.getModel().getText()
     new BufferedProcess
       command: 'git'
       args: ['tag', '-a', tag.name, '-m', tag.message]
@@ -37,7 +39,7 @@ class TagCreateView extends View
         new StatusView(type: 'alert', message: data.toString())
       exit: (code) ->
         new StatusView(type: 'success', message: "Tag '#{tag.name}' has been created successfully!") if code is 0
-    @detach()
+    @destroy()
 
-  abort: ->
-    @detach()
+  destroy: ->
+    @panel.destroy()

--- a/lib/views/tag-create-view.coffee
+++ b/lib/views/tag-create-view.coffee
@@ -11,7 +11,7 @@ module.exports=
 class TagCreateView extends View
 
   @content: ->
-    @div class: 'overlay from-top', =>
+    @div =>
       @div class: 'block', =>
         @subview 'tagName', new TextEditorView(mini: true, placeholderText: 'Tag')
       @div class: 'block', =>

--- a/lib/views/tag-create-view.coffee
+++ b/lib/views/tag-create-view.coffee
@@ -20,7 +20,7 @@ class TagCreateView extends View
         @span class: 'pull-left', =>
           @button class: 'btn btn-success inline-block-tight gp-confirm-button', click: 'createTag', 'Create Tag'
         @span class: 'pull-right', =>
-          @button class: 'btn btn-error inline-block-tight gp-cancel-button', click: 'abort', 'Cancel'
+          @button class: 'btn btn-error inline-block-tight gp-cancel-button', click: 'destroy', 'Cancel'
 
   initialize: ->
     @panel ?= atom.workspace.addModalPanel(item: this)


### PR DESCRIPTION
This PR removes the remaining deprecated calls to `atom.workspaceView`. It also includes two other minor enhancements:
1. Create a tag from the proper view on `core:confirm` (the button had to be pressed before)
2. Add `Git Run` to the git-plus palette. (This function was added in v4.0.0 when the git-plus palette was removed. When the palette was reintroduced, it was never updates to includes this function.)

I am not 100% sure this removes all deprecated API calls since there aren't comprehensive specs, but I haven't noticed deprecation cop flag anything yet.
