### PR TITLE
Fail gracefully when git cmd not found

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -26,13 +26,16 @@ gitCmd = ({args, options, stdout, stderr, exit}={}) ->
       c_stdout @save ?= ''
       @save = null
 
-  new BufferedProcess
-    command: command
-    args: args
-    options: options
-    stdout: stdout
-    stderr: stderr
-    exit: exit
+  try
+    new BufferedProcess
+      command: command
+      args: args
+      options: options
+      stdout: stdout
+      stderr: stderr
+      exit: exit
+  catch error
+    new StatusView(type: 'alert', message: 'Git Plus is unable to locate git command. Please ensure process.env.PATH can access git.')
 
 gitStatus = (stdout) ->
   gitCmd


### PR DESCRIPTION
This error occurs when the git command is not found:

```
 Failed to activate package named 'git-plus' Error: spawn EACCES
  at exports._errnoException (util.js:753:11)
  at ChildProcess.spawn (child_process.js:1160:11)
  at Object.exports.spawn (child_process.js:993:9)
  at new BufferedProcess (/Applications/Atom.app/Contents/Resources/app/src/buffered-process.js:51:37)
  at gitCmd (/Users/trangpham/.atom/packages/git-plus/lib/git.coffee:29:7)
  at Object.gitRefreshIndex [as refresh] (/Users/trangpham/.atom/packages/git-plus/lib/git.coffee:79:3)
  at Object.module.exports.activate (/Users/trangpham/.atom/packages/git-plus/lib/git-plus.coffee:71:11)
  at Package.module.exports.Package.activateNow (/Applications/Atom.app/Contents/Resources/app/src/package.js:235:27)
  at /Applications/Atom.app/Contents/Resources/app/src/package.js:710:29
  at Emitter.module.exports.Emitter.emit (/Applications/Atom.app/Contents/Resources/app/node_modules/event-kit/lib/emitter.js:82:11)
  at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/Applications/Atom.app/Contents/Resources/app/src/command-registry.js:224:20)
  at CommandRegistry.handleCommandEvent (/Applications/Atom.app/Contents/Resources/app/src/command-registry.js:3:61)
  at CommandRegistry.module.exports.CommandRegistry.dispatch (/Applications/Atom.app/Contents/Resources/app/src/command-registry.js:156:19)
  at EventEmitter.<anonymous> (/Applications/Atom.app/Contents/Resources/app/src/window-event-handler.js:65:30)
  at EventEmitter.emit (events.js:116:17)
```

This will show an alert message to the user.

Related to https://github.com/atom/atom-shell/issues/550