### PR TITLE
Fix destruction of GitRepository objects

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -156,9 +156,9 @@ getRepo = ->
   repo = GitRepository.open(atom.workspace.getActiveEditor()?.getPath())
   if repo is not null
     data = {
-      references: toDestroy.getReferences()
-      shortHead: toDestroy.getShortHead()
-      workingDirectory: toDestroy.getWorkingDirectory()
+      references: repo.getReferences()
+      shortHead: repo.getShortHead()
+      workingDirectory: repo.getWorkingDirectory()
     }
     repo.destroy()
     return {

--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -167,6 +167,7 @@ getRepo = ->
       getWorkingDirectory: -> data.workingDirectory
     }
   else
+    repo.destroy()
     return atom.project.getRepo()
 
 module.exports.cmd = gitCmd


### PR DESCRIPTION
The previous few sets of modifications didn't full fix #158. Even if the GitRepository object is null, it seems to try and refresh it when the window gets focus. This PR destroys the object in the `getRepo` method in both the if and else branches. I tested it out and this seems to fix #158` for good.