### PR TITLE
Quick and dirty fix for #194

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -91,6 +91,11 @@ gitRefreshIndex = (repo=null)->
     repo.destroy?()
   else
     repo.refreshStatus()
+    atom.project.getRepositories()
+      .filter (r) ->
+        r.path is repo.path
+      .forEach (r) ->
+        r.refreshStatus()
   gitCmd
     args: ['add', '--refresh', '--', '.']
     stderr: (data) -> # don't really need to flash an error


### PR DESCRIPTION
Since git-plus works on temporary repository objects, TreeView does not seem pick up on events from them. So in order to update TreeView, one *has* to update project's repositories, I think.

More involved fix would be to get project repositories  right away, if possible, and work on those, but I'm not sure if that would have any undesirable side effects.