### PR TITLE
Added minor fix for syntax highlighting.

### DIFF
--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -46,10 +46,10 @@ module.exports =
       default: true
       description: 'Allow commands to open new panes'
     splitPane:
-      title: 'Split pane direction(up, right, down, or left)'
+      title: 'Split pane direction (up, right, down, or left)'
       type: 'string'
       default: 'right'
-      description: 'Where should new panes go?(Defaults to right)'
+      description: 'Where should new panes go? (Defaults to right)'
     wordDiff:
       type: 'boolean'
       default: true

--- a/lib/models/git-commit.coffee
+++ b/lib/models/git-commit.coffee
@@ -62,7 +62,7 @@ class GitCommit
   # status - The current status as {String}.
   prepFile: (status) ->
     # format the status to be ignored in the commit message
-    status = status.replace(/\s*\(.*\)\n/g, '')
+    status = status.replace(/\s*\(.*\)\n/g, "\n")
     status = status.trim().replace(/\n/g, "\n#{@commentchar} ")
     fs.writeFileSync @filePath(),
       """#{@amend}


### PR DESCRIPTION
I have added a tiny fix that was preventing syntax highlighting occurring when using git-plus to make a commit on a branch that was ahead of its remote-tracking branch. This was caused by a lack of newline before the ‘Changes to be committed:’ line in the commit message.

Also inserted missing spaces in items to be displayed when viewing ‘Settings’ in Atom.