### PR TITLE
Made git-diff's matching non-greedy.

### DIFF
--- a/grammars/diff.cson
+++ b/grammars/diff.cson
@@ -55,11 +55,11 @@
     'name': 'markup.deleted.diff'
   }
   {
-    'match': '\\[\\-(.*)?\\-\\]'
+    'match': '\\[\\-.*?\\-\\]'
     'name': 'markup.deleted.diff'
   }
   {
-    'match': '\\{\\+(.*)?\\+\\}'
+    'match': '\\{\\+.*?\\+\\}'
     'name': 'markup.inserted.diff'
   }
 


### PR DESCRIPTION
I've encountered the same problem as @nixxquality described in #222, where code is incorrectly highlighted. The simple solution is to make the match non-greedy.
Before:
![Example of issue from #222](https://camo.githubusercontent.com/b17e59eb35ac1a6654bbd2159513e378be299a73/687474703a2f2f692e696d6775722e636f6d2f6b7374316633512e706e67)
After:
![No such issue](https://cloud.githubusercontent.com/assets/703602/8718513/23d64d88-2ba5-11e5-88ff-232b015ebbb8.png)