### PR TITLE
Fix not being able to delete local branches that contain slashes.

### DIFF
--- a/lib/models/git-delete-local-branch.coffee
+++ b/lib/models/git-delete-local-branch.coffee
@@ -5,6 +5,6 @@ gitDeleteLocalBranch = (repo) ->
   git.cmd
     args: ['branch']
     cwd: repo.getWorkingDirectory()
-    stdout: (data) -> new ListView(repo, data.toString())
+    stdout: (data) -> new ListView(repo, data.toString(), false)
 
 module.exports = gitDeleteLocalBranch

--- a/lib/models/git-delete-remote-branch.coffee
+++ b/lib/models/git-delete-remote-branch.coffee
@@ -6,6 +6,6 @@ gitDeleteRemoteBranch = (repo) ->
     args: ['branch', '-r']
     cwd: repo.getWorkingDirectory()
     stdout: (data) ->
-      new ListView(repo, data.toString())
+      new ListView(repo, data.toString(), true)
 
 module.exports = gitDeleteRemoteBranch

--- a/lib/views/delete-branch-view.coffee
+++ b/lib/views/delete-branch-view.coffee
@@ -5,13 +5,13 @@ BranchListView = require './branch-list-view'
 module.exports =
   # Extension of BranchListView
   class DeleteBranchListView extends BranchListView
-    initialize: (@repo, @data) -> super
+    initialize: (@repo, @data, @isRemote) -> super
 
     confirmed: ({name}) ->
       if name.startsWith "*"
         name = name.slice(1)
 
-      if name.indexOf('/') is -1
+      if not @isRemote
         @delete name
       else
         branch = name.substring(name.indexOf('/') + 1)


### PR DESCRIPTION
Hello

This should fix issue #233. The problem was apparently that the code assumes that branches with slashes are remote branches, while you can also have local branches such as user/bugfix-foo using a remote origin/user/bugfix-foo.

I've never worked with CoffeeScript before, my apologies if I'm doing something completely wrong.