### PR TITLE
Added git difftool support

### DIFF
--- a/lib/git-plus-commands.coffee
+++ b/lib/git-plus-commands.coffee
@@ -14,6 +14,7 @@ getCommands = ->
   GitCommit              = require './models/git-commit'
   GitCommitAmend         = require './models/git-commit-amend'
   GitDiff                = require './models/git-diff'
+  GitDifftool            = require './models/git-difftool'
   GitDiffAll             = require './models/git-diff-all'
   GitFetch               = require './models/git-fetch'
   GitFetchPrune          = require './models/git-fetch-prune.coffee'
@@ -59,6 +60,7 @@ getCommands = ->
       commands.push ['git-plus:delete-remote-branch', 'Delete Remote Branch', -> GitDeleteRemoteBranch(repo)]
       commands.push ['git-plus:cherry-pick', 'Cherry-Pick', -> GitCherryPick(repo)]
       commands.push ['git-plus:diff', 'Diff', -> GitDiff(repo)]
+      commands.push ['git-plus:difftool', 'Difftool', -> GitDifftool(repo)]
       commands.push ['git-plus:diff-all', 'Diff All', -> GitDiffAll(repo)]
       commands.push ['git-plus:fetch', 'Fetch', -> GitFetch(repo)]
       commands.push ['git-plus:fetch-prune', 'Fetch Prune', -> GitFetchPrune(repo)]

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -14,6 +14,7 @@ GitCherryPick          = require './models/git-cherry-pick'
 GitCommit              = require './models/git-commit'
 GitCommitAmend         = require './models/git-commit-amend'
 GitDiff                = require './models/git-diff'
+GitDifftool            = require './models/git-difftool'
 GitDiffAll             = require './models/git-diff-all'
 GitFetch               = require './models/git-fetch'
 GitFetchPrune          = require './models/git-fetch-prune.coffee'
@@ -92,6 +93,7 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:delete-remote-branch', -> git.getRepo().then((repo) -> GitDeleteRemoteBranch(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:cherry-pick', -> git.getRepo().then((repo) -> GitCherryPick(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:diff', -> git.getRepo().then((repo) -> GitDiff(repo))
+    @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:difftool', -> git.getRepo().then((repo) -> GitDifftool(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:diff-all', -> git.getRepo().then((repo) -> GitDiffAll(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:fetch', -> git.getRepo().then((repo) -> GitFetch(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:fetch-prune', -> git.getRepo().then((repo) -> GitFetchPrune(repo))

--- a/lib/models/git-difftool.coffee
+++ b/lib/models/git-difftool.coffee
@@ -1,0 +1,30 @@
+git = require '../git'
+notifier = require '../notifier'
+
+gitDifftool = (repo, {file}={}) ->
+  file ?= repo.relativize(atom.workspace.getActiveTextEditor()?.getPath())
+  if not file
+    return notifier.addError "No open file. Select 'Diff All'."
+  # We parse the output of git diff-index to handle the case of a staged file
+  # when git-plus.includeStagedDiff is set to false.
+  git.cmd
+    args: ['diff-index', 'HEAD', '-z']
+    cwd: repo.getWorkingDirectory()
+    stdout: (data) ->
+      diffIndex = data.split('\0')
+      includeStagedDiff = atom.config.get 'git-plus.includeStagedDiff'
+      for line, i in diffIndex by 2
+        staged = diffIndex[i].split(' ')[3] isnt "0000000000000000000000000000000000000000"
+        path = diffIndex[i+1]
+        if path is file and (!staged or includeStagedDiff)
+          args = ['difftool']
+          args.push 'HEAD' if includeStagedDiff
+          args.push file
+          git.cmd
+            args: args
+            cwd: repo.getWorkingDirectory()
+          return
+      # If file is unchanged, or staged, but git-plus.includeStagedDiff unchecked
+      notifier.addInfo 'Nothing to show.'
+
+module.exports = gitDifftool

--- a/lib/models/git-difftool.coffee
+++ b/lib/models/git-difftool.coffee
@@ -14,7 +14,7 @@ gitDifftool = (repo, {file}={}) ->
       diffIndex = data.split('\0')
       includeStagedDiff = atom.config.get 'git-plus.includeStagedDiff'
       for line, i in diffIndex by 2
-        staged = diffIndex[i].split(' ')[3] isnt "0000000000000000000000000000000000000000"
+        staged = not /^0{40}$/.test(diffIndex[i].split(' ')[3]);
         path = diffIndex[i+1]
         if path is file and (!staged or includeStagedDiff)
           args = ['difftool']

--- a/menus/git-plus.cson
+++ b/menus/git-plus.cson
@@ -17,6 +17,7 @@
         { 'label': 'Add All', 'command': 'git-plus:add-all' }
         { 'label': 'Commit', 'command': 'git-plus:commit' }
         { 'label': 'Diff', 'command': 'git-plus:diff' }
+        { 'label': 'Difftool', 'command': 'git-plus:difftool' }
         { 'label': 'Diff All', 'command': 'git-plus:diff-all' }
         { 'label': 'Add & Commit', 'command': 'git-plus:add-and-commit'}
         { 'label': 'Add All & Commit', 'command': 'git-plus:add-all-and-commit'}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
       "git-plus:add-and-commit",
       "git-plus:diff-all",
       "git-plus:diff",
+      "git-plus:difftool",
       "git-plus:log",
       "git-plus:log-current-file",
       "git-plus:status",


### PR DESCRIPTION
Hi, great job on this atom package!

Here's a commit to add support for the "git difftool" command, so that we can spawn our favorite diff viewer from atom.

I'm a newbie to atom package development, so I hope my code is good enough that we can discuss this merge. I basically created a new "lib/models/git-difftool.coffee" file, based on "lib/models/git-diff.coffee", and looked for diff-related stuff in the package and added some difftool equivalents wherever it made sense.

The gitDiffTool module basically launches the command "git difftool", but there's a little twist ; I wanted to display a notification that says "Nothing to show" in both of these cases:

- When a file is unchanged
- When a file is staged and the package is set to ignore staged diffs (git-plus.includeStagedDiff is false)

To do this, I had to parse the output of git diff-index. I'm not sure if it's the ideal way.

One thing that is missing is detecting if an external diff viewer is actually configured! I assume that would involve parsing the output of "git config", but I'm not sure how to proceed with that, if you have any pointers, I'll gladly take them.