### PR TITLE
Adding add-all-commit-and-push as an activation command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "git-plus:add",
       "git-plus:add-all",
       "git-plus:add-all-and-commit",
+      "git-plus:add-all-commit-and-push",
       "git-plus:add-and-commit",
       "git-plus:diff-all",
       "git-plus:diff",


### PR DESCRIPTION
Currently you have to manually select another command to activate the package, I get the feeling that this is more of a bug than an intended feature.