### PR TITLE
Git Rebase

### DIFF
--- a/lib/git-plus-commands.coffee
+++ b/lib/git-plus-commands.coffee
@@ -34,6 +34,7 @@ getCommands = ->
   GitUnstageFiles        = require './models/git-unstage-files'
   GitRun                 = require './models/git-run'
   GitMerge               = require './models/git-merge'
+  GitRebase              = require './models/git-rebase'
 
   git.getRepo()
     .then (repo) ->
@@ -79,6 +80,7 @@ getCommands = ->
       commands.push ['git-plus:tags', 'Tags', -> GitTags(repo)]
       commands.push ['git-plus:run', 'Run', -> new GitRun(repo)]
       commands.push ['git-plus:merge', 'Merge', -> GitMerge(repo)]
+      commands.push ['git-plus:rebase', 'Rebase', -> GitRebase(repo)]
 
       return commands
 

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -34,6 +34,7 @@ GitTags                = require './models/git-tags'
 GitUnstageFiles        = require './models/git-unstage-files'
 GitRun                 = require './models/git-run'
 GitMerge               = require './models/git-merge'
+GitRebase              = require './models/git-rebase'
 
 module.exports =
   config:
@@ -115,5 +116,6 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:tags', -> git.getRepo().then((repo) -> GitTags(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:run', -> git.getRepo().then((repo) -> new GitRun(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:merge', -> git.getRepo().then((repo) -> GitMerge(repo))
+    @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:rebase', -> git.getRepo().then((repo) -> GitRebase(repo))
 
   deactivate: -> @subscriptions.dispose()

--- a/lib/models/git-rebase.coffee
+++ b/lib/models/git-rebase.coffee
@@ -1,0 +1,9 @@
+git = require '../git'
+RebaseListView = require '../views/rebase-list-view'
+
+module.exports = (repo) ->
+  git.cmd
+    args: ['branch']
+    cwd: repo.getWorkingDirectory()
+    stdout: (data) ->
+      new RebaseListView(repo, data)

--- a/lib/views/branch-list-view.coffee
+++ b/lib/views/branch-list-view.coffee
@@ -55,7 +55,7 @@ class ListView extends SelectListView
       cwd: @repo.getWorkingDirectory()
       args: @args.concat(branch)
       # using `stderr` for success here
-      stderr: (data) =>
+      stderr: (data) =>f
         notifier.addSuccess data.toString()
         atom.workspace.observeTextEditors (editor) =>
           if filepath = editor.getPath()?.toString()

--- a/lib/views/branch-list-view.coffee
+++ b/lib/views/branch-list-view.coffee
@@ -55,7 +55,7 @@ class ListView extends SelectListView
       cwd: @repo.getWorkingDirectory()
       args: @args.concat(branch)
       # using `stderr` for success here
-      stderr: (data) =>f
+      stderr: (data) =>
         notifier.addSuccess data.toString()
         atom.workspace.observeTextEditors (editor) =>
           if filepath = editor.getPath()?.toString()

--- a/lib/views/rebase-list-view.coffee
+++ b/lib/views/rebase-list-view.coffee
@@ -1,0 +1,60 @@
+fs = require 'fs-plus'
+{$$, SelectListView} = require 'atom-space-pen-views'
+git = require '../git'
+notifier = require '../notifier'
+
+module.exports =
+  class ListView extends SelectListView
+    initialize: (@repo, @data) ->
+      super
+      @show()
+      @parseData()
+
+    parseData: ->
+      items = @data.split("\n")
+      branches = []
+      for item in items
+        item = item.replace(/\s/g, '')
+        unless item is ''
+          branches.push {name: item}
+      @setItems branches
+      @focusFilterEditor()
+
+    getFilterKey: -> 'name'
+
+    show: ->
+      @panel ?= atom.workspace.addModalPanel(item: this)
+      @panel.show()
+      @storeFocusedElement()
+
+    cancelled: -> @hide()
+
+    hide: ->
+      @panel?.destroy()
+
+    viewForItem: ({name}) ->
+      current = false
+      if name.startsWith "*"
+        name = name.slice(1)
+        current = true
+      $$ ->
+        @li name, =>
+          @div class: 'pull-right', =>
+            @span('Current') if current
+
+    confirmed: ({name}) ->
+      @rebase name.match(/\*?(.*)/)[1]
+      @cancel()
+
+    rebase: (branch) ->
+      git.cmd
+        args: ['rebase', branch]
+        cwd: @repo.getWorkingDirectory()
+        stdout: (data) =>
+          notifier.addSuccess data.toString()
+          atom.workspace.getTextEditors().forEach (editor) ->
+            fs.exists editor.getPath(), (exist) -> editor.destroy() if not exist
+          git.refresh()
+        stderr: (data) =>
+          notifier.addError data.toString()
+          git.refresh()

--- a/menus/git-plus.cson
+++ b/menus/git-plus.cson
@@ -25,6 +25,7 @@
         { 'label': 'Log', 'command': 'git-plus:log' }
         { 'label': 'Merge', 'command': 'git-plus:merge'},
         { 'label': 'Pull Using Rebase', 'command': 'git-plus:pull-using-rebase'}
+        { 'label': 'Rebase', 'command': 'git-plus:rebase'}
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       "git-plus:unstage-files",
       "git-plus:init",
       "git-plus:run",
-      "git-plus:merge"
+      "git-plus:merge",
+      "git-plus:rebase"
     ]
   },
   "repository": "https://github.com/akonwi/git-plus",


### PR DESCRIPTION
Adds the ability to rebase against local branches from within Atom. If
conflicts arise, the user must drop to the command line to repair it
manually.

Also doesn't currently open the conflicted files, unlike git-merge. I
actually am not sure how that happens.