### PR TITLE
Fix for akonwi/git-plus#322.

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -44,7 +44,7 @@ getRepoForCurrentFile = ->
       reject "no current file"
 
 module.exports = git =
-  cmd: (args, options={}) ->
+  cmd: (args, options={ env: process.env }) ->
     new Promise (resolve, reject) ->
       output = ''
       try


### PR DESCRIPTION
Pass process.env to BufferedProcess, otherwise package cant find git binary on PATH in Windows OSes.