### PR TITLE
Make notifications dismissable

### DIFF
--- a/lib/notifier.coffee
+++ b/lib/notifier.coffee
@@ -4,10 +4,12 @@ notify = require('atom-notify')('Git-Plus')
 notify.addSuccess = ->
   note = addSuccess.call notify, arguments..., dismissable: true
   setTimeout((=> note.dismiss()), 5000)
+  return note
 
 notify.addInfo = ->
   note = addInfo.call notify, arguments..., dismissable: true
   setTimeout((=> note.dismiss()), 5000)
+  return note
 
 notify.addError = ->
   note = addError.call notify, arguments..., dismissable: true
@@ -15,5 +17,6 @@ notify.addError = ->
 notify.addWarning = ->
   note = addWarning.call notify, arguments..., dismissable: true
   setTimeout((=> note.dismiss()), 5000)
+  return note
 
 module.exports = notify

--- a/lib/notifier.coffee
+++ b/lib/notifier.coffee
@@ -2,15 +2,18 @@ notify = require('atom-notify')('Git-Plus')
 {addSuccess, addInfo, addError, addWarning} = notify
 
 notify.addSuccess = ->
-  addSuccess.call notify, arguments..., dismissable: true
+  note = addSuccess.call notify, arguments..., dismissable: true
+  setTimeout((=> note.dismiss()), 5000)
 
 notify.addInfo = ->
-  addInfo.call notify, arguments..., dismissable: true
+  note = addInfo.call notify, arguments..., dismissable: true
+  setTimeout((=> note.dismiss()), 5000)
 
 notify.addError = ->
-  addError.call notify, arguments..., dismissable: true
+  note = addError.call notify, arguments..., dismissable: true
 
 notify.addWarning = ->
-  addWarning.call notify, arguments..., dismissable: true
+  note = addWarning.call notify, arguments..., dismissable: true
+  setTimeout((=> note.dismiss()), 5000)
 
 module.exports = notify

--- a/lib/notifier.coffee
+++ b/lib/notifier.coffee
@@ -1,1 +1,16 @@
-module.exports = require('atom-notify')('Git-Plus')
+notify = require('atom-notify')('Git-Plus')
+{addSuccess, addInfo, addError, addWarning} = notify
+
+notify.addSuccess = ->
+  addSuccess.call notify, arguments..., dismissable: true
+
+notify.addInfo = ->
+  addInfo.call notify, arguments..., dismissable: true
+
+notify.addError = ->
+  addError.call notify, arguments..., dismissable: true
+
+notify.addWarning = ->
+  addWarning.call notify, arguments..., dismissable: true
+
+module.exports = notify


### PR DESCRIPTION
Success alerts are always great to see, but sometimes you get the memo long before it decides to close.

These alerts get in the way of panes, tabs, and code, so it'd be nice if there we're a option to close the menu alongside its auto-closing timer, this way we don't have to wait for it to close before we can click something its covering.