### PR TITLE
Fix height for long log outputs

### DIFF
--- a/styles/git-plus.less
+++ b/styles/git-plus.less
@@ -19,6 +19,7 @@
 
   .info-view {
     overflow: auto;
+    max-height: 30vh;
   }
 }
 


### PR DESCRIPTION
When update log is too large, and the pin icon is clicked to bring the log back up after it disappears automatically, there's no way to dismiss it without getting a new log that will overwrite the last one. 

Value could be set to anything, but I think this is a reasonable height to use because it's scrollable anyway, and shouldn't take *that* much way either way.