### PR TITLE
Fix bug #340 - commit editor/pane doesn't close.

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -53,17 +53,23 @@ module.exports = git =
           args: args
           options: options
           stdout: (data) -> output += data.toString()
-          stderr: (data) -> reject data.toString()
-          exit: (code) -> resolve output
+          stderr: (data) -> 
+            output += data.toString()
+          exit: (code) -> 
+            if code is 0
+              resolve output 
+            else 
+              reject output 
       catch
         notifier.addError 'Git Plus is unable to locate the git command. Please ensure process.env.PATH can access git.'
         reject "Couldn't find git"
 
   getConfig: (setting, workingDirectory=null) ->
-    if workingDirectory?
-      git.cmd ['config', '--get', setting], cwd: workingDirectory
-    else
-      git.cmd ['config', '--get', setting], cwd: Path.get('~')
+    workingDirectory ?= Path.get('~')
+    git.cmd(['config', '--get', setting], cwd: workingDirectory).catch (error) ->
+      if error? and error isnt ''
+        throw error
+      ''
 
   reset: (repo) ->
     git.cmd(['reset', 'HEAD'], cwd: repo.getWorkingDirectory()).then () -> notifier.addSuccess 'All changes unstaged'

--- a/lib/models/git-commit.coffee
+++ b/lib/models/git-commit.coffee
@@ -55,6 +55,8 @@ commit = (directory, filePath) ->
     notifier.addSuccess data
     destroyCommitEditor()
     git.refresh()
+  .catch (data) ->
+    notifier.addError data
 
 cleanup = (currentPane, filePath) ->
   currentPane.activate() if currentPane.alive

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "fs-plus": "^2.2.0",
+    "fs-extra": "^0.26.2",
     "fuzzaldrin": "^1.2.0",
     "underscore-plus": "1.x",
     "atom-space-pen-views": "^2.0.3",

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -1,4 +1,4 @@
-fs = require 'fs-plus'
+fs = require 'fs-extra'
 Path = require 'flavored-path'
 git = require '../lib/git'
 {
@@ -31,11 +31,9 @@ describe "Git-Plus git module", ->
   describe "git.getConfig", ->
     args = ['config', '--get', 'user.name']
 
-    beforeEach ->
-      spyOn(git, 'cmd').andReturn Promise.resolve 'akonwi'
-
     describe "when a repo file path isn't specified", ->
       it "spawns a command querying git for the given global setting", ->
+        spyOn(git, 'cmd').andReturn Promise.resolve 'akonwi'
         waitsForPromise ->
           git.getConfig('user.name')
         runs ->
@@ -43,10 +41,29 @@ describe "Git-Plus git module", ->
 
     describe "when a repo file path is specified", ->
       it "checks for settings in that repo", ->
+        spyOn(git, 'cmd').andReturn Promise.resolve 'akonwi'
         waitsForPromise ->
           git.getConfig('user.name', repo.getWorkingDirectory())
         runs ->
           expect(git.cmd).toHaveBeenCalledWith args, cwd: repo.getWorkingDirectory()
+
+    describe "when the command fails without an error message", ->
+      it "resolves to ''", ->
+        spyOn(git, 'cmd').andReturn Promise.reject ''
+        waitsForPromise ->
+          git.getConfig('user.name', repo.getWorkingDirectory()).then (result) ->
+            expect(result).toEqual('')
+        runs ->
+          expect(git.cmd).toHaveBeenCalledWith args, cwd: repo.getWorkingDirectory()
+
+    describe "when the command fails with an error message", ->
+      it "rejects with the error message", ->
+        spyOn(git, 'cmd').andReturn Promise.reject 'getConfig error'
+        waitsForPromise ->
+          git.getConfig('user.name', 'bad working dir').then (result) ->
+            fail "should have been rejected"
+          .catch (error) ->
+            expect(error).toEqual('getConfig error')
 
   describe "git.getRepo", ->
     it "returns a promise resolving to repository", ->
@@ -78,9 +95,33 @@ describe "Git-Plus git module", ->
 
   describe "git.cmd", ->
     it "returns a promise", ->
-      promise = git.cmd()
-      expect(promise.catch).toBeDefined()
-      expect(promise.then).toBeDefined()
+      waitsForPromise ->
+        promise = git.cmd()
+        expect(promise.catch).toBeDefined()
+        expect(promise.then).toBeDefined()
+        return promise.catch (output) ->
+          expect(output).toContain('usage')
+      
+    it "returns a promise that is fulfilled with stdout on success", ->
+      waitsForPromise ->
+        git.cmd(['--version']).then (output) ->
+          expect(output).toContain('git version')
+
+    it "returns a promise that is rejected with stderr on failure", ->
+      waitsForPromise ->
+        git.cmd(['help', '--bogus-option']).catch (output) ->
+          expect(output).toContain('unknown option')
+
+    it "returns a promise that is fulfilled with stderr on success", ->
+      initDir = 'git-plus-test-dir' + Math.random()
+      cloneDir = initDir + '-clone'
+      waitsForPromise ->
+        git.cmd(['init', initDir]).then () ->
+          git.cmd(['clone', '--progress', initDir, cloneDir])  
+        .then (output) ->
+          fs.removeSync(initDir)
+          fs.removeSync(cloneDir)
+          expect(output).toContain('Cloning')
 
   describe "git.add", ->
     it "calls git.cmd with ['add', '--all', {fileName}]", ->


### PR DESCRIPTION
In git.cmd, make the stderr callback identical to the stdout callback so that
they append to the same output string and make the exit callback reject(output)
if the exit code is non-zero, and resolve(output) if it is zero.

Fix git.getConfig to handle the rejection when a key is not set.

Add a catch() callback to GitCommit.commit that notifies the user of a commit
failure (so that failures won't be silent) and doesn't destroy the editor .