### PR TITLE
Readme Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ _Commands are accessible for keybindings by dasherizing the command title._
 | `Git Log [Current File]` | Show the commit history [for the current file] and show display the selected commit. | |
 | `Git Show` | Show the specified object, for example `HEAD`, `HEAD~2`,`3925a0d`, `origin/master` or `v2.7.3`. | |
 
+###Commit window
+To change where the commit window appears go to settings and find
+![screenshot](http://imgur.com/cdc7M5p.png)
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
I added some information and a picture about the split pane direction in the readme.
When I first downloaded the plugin I could not find how to change it.
Some of my developer friends had the same problem.