### PR TITLE
Add command to open all changed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ _Commands are accessible for keybindings by dasherizing the command title._
 | `Git rm [current file]` | `git rm` the current file or open an selector to select the files to remove. You can select multiple files at once. | |
 | `Git Log [Current File]` | Show the commit history [for the current file] and show display the selected commit. | |
 | `Git Show` | Show the specified object, for example `HEAD`, `HEAD~2`,`3925a0d`, `origin/master` or `v2.7.3`. | |
+| `Git Open Changed Files` | Open tabs with all added, modified or renamed files. | |
 
 ### Commit window
 To change where the commit window appears go to settings and find

--- a/lib/git-plus-commands.coffee
+++ b/lib/git-plus-commands.coffee
@@ -34,6 +34,7 @@ getCommands = ->
   GitRun                 = require './models/git-run'
   GitMerge               = require './models/git-merge'
   GitRebase              = require './models/git-rebase'
+  GitOpenChangedFiles    = require './models/git-open-changed-files'
 
   git.getRepo()
     .then (repo) ->
@@ -84,6 +85,7 @@ getCommands = ->
       commands.push ['git-plus:merge', 'Merge', -> GitMerge(repo)]
       commands.push ['git-plus:merge-remote', 'Merge Remote', -> GitMerge(repo, remote: true)]
       commands.push ['git-plus:rebase', 'Rebase', -> GitRebase(repo)]
+      commands.push ['git-plus:git-open-changed-files', 'Open Changed Files', -> GitOpenChangedFiles(repo)]
 
       return commands
 

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -36,6 +36,7 @@ GitUnstageFiles        = require './models/git-unstage-files'
 GitRun                 = require './models/git-run'
 GitMerge               = require './models/git-merge'
 GitRebase              = require './models/git-rebase'
+GitOpenChangedFiles    = require './models/git-open-changed-files'
 
 currentFile = (repo) ->
   repo.relativize(atom.workspace.getActiveTextEditor()?.getPath())
@@ -130,6 +131,7 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:merge', -> git.getRepo().then((repo) -> GitMerge(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:merge-remote', -> git.getRepo().then((repo) -> GitMerge(repo, remote: true))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:rebase', -> git.getRepo().then((repo) -> GitRebase(repo))
+    @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:git-open-changed-files', -> git.getRepo().then((repo) -> GitOpenChangedFiles(repo))
 
   deactivate: ->
     @subscriptions.dispose()

--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -73,7 +73,7 @@ module.exports = git =
 
   status: (repo) ->
     git.cmd(['status', '--porcelain', '-z'], cwd: repo.getWorkingDirectory())
-    .then (data) -> if data.length > 2 then data.split('\0') else []
+    .then (data) -> if data.length > 2 then data.split('\0')[...-1] else []
 
   refresh: () ->
     atom.project.getRepositories().forEach (repo) ->

--- a/lib/models/git-open-changed-files.coffee
+++ b/lib/models/git-open-changed-files.coffee
@@ -1,0 +1,13 @@
+git = require '../git'
+
+filesFromData = (statusData) ->
+  files = []
+  for line in statusData
+    lineMatch = line.match /^([ MARCU?!]{2})\s{1}(.*)/
+    files.push lineMatch[2] if lineMatch
+  files
+
+module.exports = (repo) ->
+  git.status(repo).then (statusData) ->
+    for file in filesFromData(statusData)
+      atom.workspace.open(file)

--- a/lib/views/status-list-view.coffee
+++ b/lib/views/status-list-view.coffee
@@ -10,7 +10,7 @@ class StatusListView extends SelectListView
   initialize: (@repo, @data) ->
     super
     @show()
-    @setItems @parseData @data[...-1]
+    @setItems @parseData @data
     @focusFilterEditor()
 
   parseData: (files) ->

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
       "git-plus:run",
       "git-plus:merge",
       "git-plus:merge-remote",
-      "git-plus:rebase"
+      "git-plus:rebase",
+      "git-plus:open-changed-files"
     ]
   },
   "consumedServices": {

--- a/spec/models/git-open-changed-files-spec.coffee
+++ b/spec/models/git-open-changed-files-spec.coffee
@@ -1,0 +1,31 @@
+git = require '../../lib/git'
+{repo} = require '../fixtures'
+GitOpenChangedFiles = require '../../lib/models/git-open-changed-files'
+
+describe "GitOpenChangedFiles", ->
+  beforeEach ->
+    spyOn(atom.workspace, 'open')
+
+  describe "when file is modified", ->
+    beforeEach ->
+      spyOn(git, 'status').andReturn Promise.resolve [' M file1.txt']
+      waitsForPromise -> GitOpenChangedFiles(repo)
+
+    it "opens changed file", ->
+      expect(atom.workspace.open).toHaveBeenCalledWith("file1.txt")
+
+  describe "when file is added", ->
+    beforeEach ->
+      spyOn(git, 'status').andReturn Promise.resolve ['?? file2.txt']
+      waitsForPromise -> GitOpenChangedFiles(repo)
+
+    it "opens added file", ->
+      expect(atom.workspace.open).toHaveBeenCalledWith("file2.txt")
+
+  describe "when file is renamed", ->
+    beforeEach ->
+      spyOn(git, 'status').andReturn Promise.resolve ['R  file3.txt']
+      waitsForPromise -> GitOpenChangedFiles(repo)
+
+    it "opens renamed file", ->
+      expect(atom.workspace.open).toHaveBeenCalledWith("file3.txt")


### PR DESCRIPTION
The command "Git Open Changed Files" (`git-plus:git-open-changed-files`) allows to quickly open all changed (added, moved or modified) files in the atom tabs. I think it can be quite useful when you return to work on some repo and want to observe all current (not commited) changes.

What do you think?