### PR TITLE
Show colorized output of git run command

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -1,5 +1,6 @@
 {BufferedProcess} = require 'atom'
 Path = require 'flavored-path'
+AnsiToHtml = require 'ansi-to-html'
 
 RepoListView = require './views/repo-list-view'
 notifier = require './notifier'
@@ -44,9 +45,10 @@ getRepoForCurrentFile = ->
       reject "no current file"
 
 module.exports = git =
-  cmd: (args, options={ env: process.env }) ->
+  cmd: (args=[], options={ env: process.env }, enableColor=false) ->
     new Promise (resolve, reject) ->
       output = ''
+      args = ['-c', 'color.ui=always'].concat(args) if enableColor
       process = new BufferedProcess
         command: atom.config.get('git-plus.gitPath') ? 'git'
         args: args
@@ -55,6 +57,7 @@ module.exports = git =
         stderr: (data) ->
           output += data.toString()
         exit: (code) ->
+          output = new AnsiToHtml().toHtml(output) if enableColor
           if code is 0
             resolve output
           else

--- a/lib/models/git-run.coffee
+++ b/lib/models/git-run.coffee
@@ -28,7 +28,7 @@ class InputView extends View
       view = OutputViewManager.create()
       args = @commandEditor.getText().split(' ')
       if args[0] is 1 then args.shift()
-      git.cmd(args, cwd: @repo.getWorkingDirectory())
+      git.cmd(args, cwd: @repo.getWorkingDirectory(), true)
       .then (data) =>
         msg = "git #{args.join(' ')} was successful"
         notifier.addSuccess(msg)

--- a/lib/views/output-view.coffee
+++ b/lib/views/output-view.coffee
@@ -7,7 +7,7 @@ module.exports =
 
     @content: ->
       @div class: 'git-plus info-view', =>
-        @pre class: 'output', defaultMessage
+        @div class: 'output', defaultMessage
 
     initialize: ->
       super
@@ -20,7 +20,7 @@ module.exports =
     reset: -> @message = defaultMessage
 
     finish: ->
-      @find(".output").text(@message)
+      @find(".output").html(@message)
       @show()
       @timeout = setTimeout =>
         @hide()

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "underscore-plus": "1.x",
     "atom-space-pen-views": "^2.0.3",
     "flavored-path": "0.0.8",
-    "atom-notify": "^1.1.0"
+    "atom-notify": "^1.1.0",
+    "ansi-to-html": "^0.4.1"
   }
 }

--- a/styles/git-plus.less
+++ b/styles/git-plus.less
@@ -20,6 +20,8 @@
   &.info-view {
     overflow: auto;
     max-height: 30vh;
+    font-family: PragmataPro, FiraCode, Monoid, Mononoki, Hack, Consolas, Inconsolata, Menlo, Monaco, monospace;
+    white-space: pre;
   }
 }
 


### PR DESCRIPTION
This PR modifies the `git-plus:run` command to show colorized output. Below is an example from running `git log --stat`.

![git-plus-opt](https://cloud.githubusercontent.com/assets/151197/16329113/8282640a-399d-11e6-9d14-f87d6332c918.png)

Also seems relevant to #459.