### PR TITLE
Only toggle output view if not opened manually

### DIFF
--- a/lib/views/output-view.coffee
+++ b/lib/views/output-view.coffee
@@ -4,6 +4,7 @@ defaultMessage = 'Nothing new to show'
 module.exports =
   class OutputView extends ScrollView
     message: ''
+    wasOpenedManually: false
 
     @content: ->
       @div class: 'git-plus info-view', =>
@@ -22,10 +23,12 @@ module.exports =
     finish: ->
       @find(".output").text(@message)
       @show()
-      @timeout = setTimeout =>
-        @hide()
-      , atom.config.get('git-plus.messageTimeout') * 1000
+      unless @wasOpenedManually
+        @timeout = setTimeout =>
+          @hide()
+        , atom.config.get('git-plus.messageTimeout') * 1000
 
     toggle: ->
       clearTimeout @timeout if @timeout
+      @wasOpenedManually = not @wasOpenedManually
       $.fn.toggle.call(this)


### PR DESCRIPTION
This PR changes the behavior of the output view so that it does not get closed on a timer (after `git-plus:run`) if it is currently open from manually toggling the status bar button. If the output view is closed when `git-plus:run` is executed, it behaves the same as before, e.g., shows the output view temporarily after the command succeeds and then hides it.