### PR TITLE
Fix package menu items

### DIFF
--- a/menus/git-plus.cson
+++ b/menus/git-plus.cson
@@ -38,19 +38,19 @@
           'command': 'git-plus:diff-all'
         }
         {
-          'label': 'Add & Commit'
+          'label': 'Add + Commit'
           'command': 'git-plus:add-and-commit'
         }
         {
-          'label': 'Add & Commit & Push'
+          'label': 'Add + Commit + Push'
           'command': 'git-plus:add-and-commit-and-push'
         }
         {
-          'label': 'Add All & Commit'
+          'label': 'Add All + Commit'
           'command': 'git-plus:add-all-and-commit'
         }
         {
-          'label': 'Add All & Commit & Push'
+          'label': 'Add All + Commit + Push'
           'command': 'git-plus:add-all-commit-and-push'
         }
         {


### PR DESCRIPTION
Ampersands (`&`) don't show up in the actual menu (at least on macOS/X) so simply replace them with `+`.