### PR TITLE
Improve branch list status-bar item and modal

### DIFF
--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -166,6 +166,7 @@ module.exports =
   setupBranchesMenuToggle: (statusBar) ->
     statusBar.getRightTiles().some ({item}) =>
       if item?.classList?.contains? 'git-view'
-        $(item).find('.git-branch').on 'click', (e) ->
-          atom.commands.dispatch(document.querySelector('atom-workspace'), 'git-plus:checkout')
+        $(item).find('.git-branch').on 'click', ({altKey, shiftKey}) ->
+          unless altKey or shiftKey
+            atom.commands.dispatch(document.querySelector('atom-workspace'), 'git-plus:checkout')
         return true

--- a/lib/views/branch-list-view.coffee
+++ b/lib/views/branch-list-view.coffee
@@ -42,7 +42,7 @@ class ListView extends SelectListView
     $$ ->
       @li name, =>
         @div class: 'pull-right', =>
-          @span('Current') if current
+          @span('HEAD') if current
 
   confirmed: ({name}) ->
     @checkout name.match(/\*?(.*)/)[1]

--- a/lib/views/branch-list-view.coffee
+++ b/lib/views/branch-list-view.coffee
@@ -9,6 +9,7 @@ class ListView extends SelectListView
 
   initialize: (@repo, @data) ->
     super
+    @addClass('git-branch')
     @show()
     @parseData()
     @currentPane = atom.workspace.getActivePane()

--- a/menus/git-plus.cson
+++ b/menus/git-plus.cson
@@ -38,19 +38,19 @@
           'command': 'git-plus:diff-all'
         }
         {
-          'label': 'Add & Commit'
+          'label': 'Add + Commit'
           'command': 'git-plus:add-and-commit'
         }
         {
-          'label': 'Add & Commit & Push'
+          'label': 'Add + Commit + Push'
           'command': 'git-plus:add-and-commit-and-push'
         }
         {
-          'label': 'Add All & Commit'
+          'label': 'Add All + Commit'
           'command': 'git-plus:add-all-and-commit'
         }
         {
-          'label': 'Add All & Commit & Push'
+          'label': 'Add All + Commit + Push'
           'command': 'git-plus:add-all-commit-and-push'
         }
         {


### PR DESCRIPTION
- Change `current` to `HEAD` branch list indicator
- Add `git-branch` to class list of branches modal
- Allow other packages to use branch _status-bar_ item
