### PR TITLE
new Feature/merge without fast forward

### DIFF
--- a/lib/git-plus-commands.coffee
+++ b/lib/git-plus-commands.coffee
@@ -85,6 +85,7 @@ getCommands = ->
       commands.push ['git-plus:run', 'Run', -> new GitRun(repo)]
       commands.push ['git-plus:merge', 'Merge', -> GitMerge(repo)]
       commands.push ['git-plus:merge-remote', 'Merge Remote', -> GitMerge(repo, remote: true)]
+      commands.push ['git-plus:merge-no-fast-forward', 'Merge without fast-forward', -> GitMerge(repo, no_fast_forward: true)]
       commands.push ['git-plus:rebase', 'Rebase', -> GitRebase(repo)]
       commands.push ['git-plus:git-open-changed-files', 'Open Changed Files', -> GitOpenChangedFiles(repo)]
 

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -139,6 +139,7 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:run', -> git.getRepo().then((repo) -> new GitRun(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:merge', -> git.getRepo().then((repo) -> GitMerge(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:merge-remote', -> git.getRepo().then((repo) -> GitMerge(repo, remote: true))
+    @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:merge-no-fast-forward', -> git.getRepo().then((repo) -> GitMerge(repo, no_fast_forward: true))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:rebase', -> git.getRepo().then((repo) -> GitRebase(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:git-open-changed-files', -> git.getRepo().then((repo) -> GitOpenChangedFiles(repo))
 

--- a/lib/models/git-merge.coffee
+++ b/lib/models/git-merge.coffee
@@ -1,8 +1,8 @@
 git = require '../git'
 MergeListView = require '../views/merge-list-view'
 
-module.exports = (repo, {remote}={}) ->
+module.exports = (repo, {remote, no_fast_forward}={}) ->
   args = ['branch']
   args.push '-r' if remote
   git.cmd(args, cwd: repo.getWorkingDirectory())
-  .then (data) -> new MergeListView(repo, data)
+  .then (data) -> new MergeListView(repo, data, `no_fast_forward ? ['--n-ff'] : null`)

--- a/lib/models/git-merge.coffee
+++ b/lib/models/git-merge.coffee
@@ -5,4 +5,4 @@ module.exports = (repo, {remote, no_fast_forward}={}) ->
   args = ['branch']
   args.push '-r' if remote
   git.cmd(args, cwd: repo.getWorkingDirectory())
-  .then (data) -> new MergeListView(repo, data, `no_fast_forward ? ['--n-ff'] : null`)
+  .then (data) -> new MergeListView(repo, data, `no_fast_forward ? ['--no-ff'] : null`)

--- a/lib/views/merge-list-view.coffee
+++ b/lib/views/merge-list-view.coffee
@@ -6,7 +6,7 @@ notifier = require '../notifier'
 
 module.exports =
 class ListView extends SelectListView
-  initialize: (@repo, @data) ->
+  initialize: (@repo, @data, @args) ->
     super
     @show()
     @parseData()
@@ -48,7 +48,10 @@ class ListView extends SelectListView
     @cancel()
 
   merge: (branch) ->
-    git.cmd(['merge', branch], cwd: @repo.getWorkingDirectory())
+    mergeArg = ['merge', branch]
+    if @args && @args.length > 0
+      mergeArg = mergeArg.concat @args
+    git.cmd(mergeArg, cwd: @repo.getWorkingDirectory())
     .then (data) ->
       OutputViewManager.create().addLine(data).finish()
       atom.workspace.getTextEditors().forEach (editor) ->

--- a/menus/git-plus.cson
+++ b/menus/git-plus.cson
@@ -63,7 +63,20 @@
         }
         {
           'label': 'Merge'
-          'command': 'git-plus:merge'
+          'submenu': [
+            {
+              'label': 'Normal Merge'
+              'command': 'git-plus:merge'
+            }
+            {
+              'label': 'Merge Remote'
+              'command': 'git-plus:merge-remote'
+            }
+            {
+              'label': 'Merge without fast-forward'
+              'command': 'git-plus:merge-no-fast-forward'
+            }
+          ]
         }
         {
           'label': 'Pull Using Rebase'

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
       "git-plus:run",
       "git-plus:merge",
       "git-plus:merge-remote",
+      "git-plus:merge-no-fast-forward",
       "git-plus:rebase",
       "git-plus:open-changed-files"
     ]


### PR DESCRIPTION
TLDR: adds a new options that render:
$ git branchName --no-ff
_also menu > merge is now a submenu _

This feature for some development teams is intended to acomplish a better cvs management
Info:
- [Here](http://nvie.com/posts/a-successful-git-branching-model/)
- [and here](http://stackoverflow.com/questions/2850369/why-does-git-fast-forward-merges-by-default) 
