### PR TITLE
Select format option in settings for git-show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 5.18.1
+- Git show defaults to HEAD if input is left empty. [pr #481](https://github.com/akonwi/git-plus/issues/481)
+
 ### 5.18.0
 - Enable activating the difftool on files and folders in the tree-view [pr #508](https://github.com/akonwi/git-plus/issues/508)
 - Allow the package to initialize immediately when atom loads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Changelog
 
-### 5.19.1
+### 5.20.0
 - Fix #510 [pr #514](https://github.com/akonwi/git-plus/issues/514)
+- Add new command (Add Modified) [pr #519](https://github.com/akonwi/git-plus/issues/519)
 
 ### 5.19.0
 - Add new command (Merge without fast-forward) [pr #492](https://github.com/akonwi/git-plus/issues/492)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 5.19.1
+- Fix #510 [pr #514](https://github.com/akonwi/git-plus/issues/514)
+
 ### 5.19.0
 - Add new command (Merge without fast-forward) [pr #492](https://github.com/akonwi/git-plus/issues/492)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 5.18.3
+- Merge [pr #489](https://github.com/akonwi/git-plus/issues/489)
+
 ### 5.18.2
 - Git show defaults to HEAD if input is left empty. [pr #481](https://github.com/akonwi/git-plus/issues/481)
 - Pin icon in status bar can now be disabled. [pr #488](https://github.com/akonwi/git-plus/issues/488)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 5.19.0
+- Add new command (Merge without fast-forward) [pr #492](https://github.com/akonwi/git-plus/issues/492)
+
 ### 5.18.3
 - Merge [pr #489](https://github.com/akonwi/git-plus/issues/489)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Changelog
 
-### 5.18.1
+### 5.18.2
 - Git show defaults to HEAD if input is left empty. [pr #481](https://github.com/akonwi/git-plus/issues/481)
+- Pin icon in status bar can now be disabled. [pr #488](https://github.com/akonwi/git-plus/issues/488)
 
 ### 5.18.0
 - Enable activating the difftool on files and folders in the tree-view [pr #508](https://github.com/akonwi/git-plus/issues/508)

--- a/lib/git-plus-commands.coffee
+++ b/lib/git-plus-commands.coffee
@@ -85,6 +85,7 @@ getCommands = ->
       commands.push ['git-plus:run', 'Run', -> new GitRun(repo)]
       commands.push ['git-plus:merge', 'Merge', -> GitMerge(repo)]
       commands.push ['git-plus:merge-remote', 'Merge Remote', -> GitMerge(repo, remote: true)]
+      commands.push ['git-plus:merge-no-fast-forward', 'Merge without fast-forward', -> GitMerge(repo, no_fast_forward: true)]
       commands.push ['git-plus:rebase', 'Rebase', -> GitRebase(repo)]
       commands.push ['git-plus:git-open-changed-files', 'Open Changed Files', -> GitOpenChangedFiles(repo)]
 

--- a/lib/git-plus-commands.coffee
+++ b/lib/git-plus-commands.coffee
@@ -42,6 +42,7 @@ getCommands = ->
       git.refresh()
       commands = []
       commands.push ['git-plus:add', 'Add', -> GitAdd(repo)]
+      commands.push ['git-plus:add-modified', 'Add Modified', -> git.add(repo, update: true)]
       commands.push ['git-plus:add-all', 'Add All', -> GitAdd(repo, addAll: true)]
       commands.push ['git-plus:log', 'Log', -> GitLog(repo)]
       commands.push ['git-plus:log-current-file', 'Log Current File', -> GitLog(repo, onlyCurrentFile: true)]

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -93,6 +93,9 @@ module.exports =
       description: '(Experimental) Show diffs in commit pane?'
       type: 'boolean'
       default: false
+    enableStatusBarIcon:
+      type: 'boolean'
+      default: true
 
   subscriptions: null
 
@@ -168,7 +171,8 @@ module.exports =
 
   consumeStatusBar: (statusBar) ->
     @setupBranchesMenuToggle statusBar
-    @setupOutputViewToggle statusBar
+    if atom.config.get 'git-plus.enableStatusBarIcon'
+      @setupOutputViewToggle statusBar
 
   setupOutputViewToggle: (statusBar) ->
     div = document.createElement 'div'

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -80,6 +80,11 @@ module.exports =
       type: 'integer'
       default: 5
       description: 'How long should success/error messages be shown?'
+    showFormat:
+      description: 'Which format to use for git show? (none will use your git config default)'
+      type: 'string'
+      default: 'full'
+      enum: ['oneline', 'short', 'medium', 'full', 'fuller', 'email', 'raw', 'none']
     pullBeforePush:
       description: 'Pull from remote before pushing'
       type: 'string'

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -189,6 +189,7 @@ module.exports =
   setupBranchesMenuToggle: (statusBar) ->
     statusBar.getRightTiles().some ({item}) =>
       if item?.classList?.contains? 'git-view'
-        $(item).find('.git-branch').on 'click', (e) ->
-          atom.commands.dispatch(document.querySelector('atom-workspace'), 'git-plus:checkout')
+        $(item).find('.git-branch').on 'click', ({altKey, shiftKey}) ->
+          unless altKey or shiftKey
+            atom.commands.dispatch(document.querySelector('atom-workspace'), 'git-plus:checkout')
         return true

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -154,6 +154,7 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:run', -> git.getRepo().then((repo) -> new GitRun(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:merge', -> git.getRepo().then((repo) -> GitMerge(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:merge-remote', -> git.getRepo().then((repo) -> GitMerge(repo, remote: true))
+    @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:merge-no-fast-forward', -> git.getRepo().then((repo) -> GitMerge(repo, no_fast_forward: true))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:rebase', -> git.getRepo().then((repo) -> GitRebase(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:git-open-changed-files', -> git.getRepo().then((repo) -> GitOpenChangedFiles(repo))
     @subscriptions.add atom.config.observe 'git-plus.syntaxHighlighting',

--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -111,6 +111,7 @@ module.exports =
       @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:init', -> GitInit()
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:menu', -> new GitPaletteView()
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:add', -> git.getRepo().then((repo) -> GitAdd(repo))
+    @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:add-modified', -> git.getRepo().then((repo) -> git.add(repo, update: true))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:add-all', -> git.getRepo().then((repo) -> GitAdd(repo, addAll: true))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:commit', -> git.getRepo().then((repo) -> GitCommit(repo))
     @subscriptions.add atom.commands.add 'atom-workspace', 'git-plus:commit-all', -> git.getRepo().then((repo) -> GitCommit(repo, stageChanges: true))

--- a/lib/grammars/diff.js
+++ b/lib/grammars/diff.js
@@ -130,10 +130,10 @@
 			removedIdx = _.isUndefined(newIdx.removed) ? removedIdx : newIdx.removed;
 			addedIdx = _.isUndefined(newIdx.added) ? addedIdx : newIdx.added;
 			if (_.contains(tokens[i].scopes, 'markup.removed.diff')) {
-				newTags = removedResult.tags;
+				newTags = removedResult && removedResult.tags;
 				newIdx = { removed: removedIdx };
 			} else if (_.contains(tokens[i].scopes, 'markup.added.diff')) {
-				newTags = addedResult.tags;
+				newTags = addedResult && addedResult.tags;
 				newIdx = { added: addedIdx };
 			} else {
 				newTags = (addedResult && addedResult.tags) || (removedResult && removedResult.tags);

--- a/lib/models/git-merge.coffee
+++ b/lib/models/git-merge.coffee
@@ -1,8 +1,9 @@
 git = require '../git'
 MergeListView = require '../views/merge-list-view'
 
-module.exports = (repo, {remote}={}) ->
+module.exports = (repo, {remote, noFastForward}={}) ->
+  extraArgs = if noFastForward then ['--no-ff'] else []
   args = ['branch']
   args.push '-r' if remote
   git.cmd(args, cwd: repo.getWorkingDirectory())
-  .then (data) -> new MergeListView(repo, data)
+  .then (data) -> new MergeListView(repo, data, extraArgs)

--- a/lib/models/git-show.coffee
+++ b/lib/models/git-show.coffee
@@ -13,11 +13,14 @@ showCommitFilePath = (objectHash) ->
 showObject = (repo, objectHash, file) ->
   args = ['show', '--color=never', '--format=full']
   args.push '--word-diff' if atom.config.get 'git-plus.wordDiff'
-  args.push objectHash
+  args.push objectHash unless isEmpty objectHash
   args.push '--', file if file?
 
   git.cmd(args, cwd: repo.getWorkingDirectory())
   .then (data) -> prepFile(data, objectHash) if data.length > 0
+
+isEmpty = (objectHash) ->
+  objectHash.length is 1 and objectHash[0].length is 0
 
 prepFile = (text, objectHash) ->
   fs.writeFile showCommitFilePath(objectHash), text, flag: 'w+', (err) ->

--- a/lib/models/git-show.coffee
+++ b/lib/models/git-show.coffee
@@ -14,7 +14,9 @@ isEmpty = (string) -> string is ''
 
 showObject = (repo, objectHash, file) ->
   objectHash = if isEmpty objectHash then 'HEAD' else objectHash
-  args = ['show', '--color=never', '--format=full']
+  args = ['show', '--color=never']
+  showFormatOption = atom.config.get 'git-plus.showFormat'
+  args.push "--format=#{showFormatOption}" if showFormatOption != 'none'
   args.push '--word-diff' if atom.config.get 'git-plus.wordDiff'
   args.push objectHash
   args.push '--', file if file?

--- a/lib/views/branch-list-view.coffee
+++ b/lib/views/branch-list-view.coffee
@@ -9,6 +9,7 @@ class ListView extends SelectListView
 
   initialize: (@repo, @data) ->
     super
+    @addClass('git-branch')
     @show()
     @parseData()
     @currentPane = atom.workspace.getActivePane()
@@ -42,7 +43,7 @@ class ListView extends SelectListView
     $$ ->
       @li name, =>
         @div class: 'pull-right', =>
-          @span('Current') if current
+          @span('HEAD') if current
 
   confirmed: ({name}) ->
     @checkout name.match(/\*?(.*)/)[1]

--- a/lib/views/merge-list-view.coffee
+++ b/lib/views/merge-list-view.coffee
@@ -6,7 +6,7 @@ notifier = require '../notifier'
 
 module.exports =
 class ListView extends SelectListView
-  initialize: (@repo, @data) ->
+  initialize: (@repo, @data, @args=[]) ->
     super
     @show()
     @parseData()
@@ -48,7 +48,8 @@ class ListView extends SelectListView
     @cancel()
 
   merge: (branch) ->
-    git.cmd(['merge', branch], cwd: @repo.getWorkingDirectory())
+    mergeArg = ['merge'].concat(@args).concat [branch]
+    git.cmd(mergeArg, cwd: @repo.getWorkingDirectory())
     .then (data) ->
       OutputViewManager.create().addLine(data).finish()
       atom.workspace.getTextEditors().forEach (editor) ->

--- a/menus/git-plus.cson
+++ b/menus/git-plus.cson
@@ -68,7 +68,20 @@
         }
         {
           'label': 'Merge'
-          'command': 'git-plus:merge'
+          'submenu': [
+            {
+              'label': 'Normal Merge'
+              'command': 'git-plus:merge'
+            }
+            {
+              'label': 'Merge Remote'
+              'command': 'git-plus:merge-remote'
+            }
+            {
+              'label': 'Merge without fast-forward'
+              'command': 'git-plus:merge-no-fast-forward'
+            }
+          ]
         }
         {
           'label': 'Pull Using Rebase'

--- a/menus/git-plus.cson
+++ b/menus/git-plus.cson
@@ -23,6 +23,10 @@
           'command': 'git-plus:add'
         }
         {
+          'label': 'Add Modified'
+          'command': 'git-plus:add-modified'
+        }
+        {
           'label': 'Add All'
           'command': 'git-plus:add-all'
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-plus",
   "main": "./lib/git-plus",
-  "version": "5.18.0",
+  "version": "5.18.2",
   "description": "Do git things without the terminal",
   "keywords": [
     "git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-plus",
   "main": "./lib/git-plus",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Do git things without the terminal",
   "keywords": [
     "git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-plus",
   "main": "./lib/git-plus",
-  "version": "5.18.3",
+  "version": "5.19.0",
   "description": "Do git things without the terminal",
   "keywords": [
     "git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-plus",
   "main": "./lib/git-plus",
-  "version": "5.18.2",
+  "version": "5.18.3",
   "description": "Do git things without the terminal",
   "keywords": [
     "git"

--- a/spec/models/git-merge-spec.coffee
+++ b/spec/models/git-merge-spec.coffee
@@ -10,7 +10,7 @@ describe "GitMerge", ->
       expect(git.cmd).toHaveBeenCalledWith ['branch'], cwd: repo.getWorkingDirectory()
 
   describe "when called with { remote: true } option", ->
-    it "calls git.cmd with 'remote branch'", ->
+    it "calls git.cmd with 'branch -r'", ->
       spyOn(git, 'cmd').andReturn Promise.resolve ''
       GitMerge(repo, remote: true)
       expect(git.cmd).toHaveBeenCalledWith ['branch', '-r'], cwd: repo.getWorkingDirectory()

--- a/spec/models/git-show-spec.coffee
+++ b/spec/models/git-show-spec.coffee
@@ -15,6 +15,12 @@ describe "GitShow", ->
     expect('show' in args).toBe true
     expect(pathToRepoFile in args).toBe true
 
+  it "uses the format option from package settings", ->
+    atom.config.set('git-plus.showFormat', 'fuller')
+    GitShow repo, 'foobar-hash', pathToRepoFile
+    args = git.cmd.mostRecentCall.args[0]
+    expect('--format=fuller' in args).toBe true
+
   it "writes the output to a file", ->
     spyOn(fs, 'writeFile').andCallFake ->
       fs.writeFile.mostRecentCall.args[3]()

--- a/spec/views/merge-list-view-spec.coffee
+++ b/spec/views/merge-list-view-spec.coffee
@@ -14,3 +14,10 @@ describe "MergeListView", ->
     @view.confirmSelection()
     waitsFor -> git.cmd.callCount > 0
     expect(git.cmd).toHaveBeenCalledWith ['merge', 'branch1'], cwd: repo.getWorkingDirectory()
+
+  describe "when passed extra arguments", ->
+    it "calls git.cmd with 'merge [extraArgs] branch1' when branch1 is selected", ->
+      view = new MergeListView(repo, "branch1", ['--no-ff'])
+      view.confirmSelection()
+      waitsFor -> git.cmd.callCount > 0
+      expect(git.cmd).toHaveBeenCalledWith ['merge', '--no-ff', 'branch1'], cwd: repo.getWorkingDirectory()


### PR DESCRIPTION
This adds an option in the settings to choose which format option for `git show` command. I've been using this because I needed the `fuller` option. Keeps `full` as the default. Not sure if it might be useful for others.

Regarding spec: want to tackle that, but I'll admit I'm a bit overwhelmed for how to write one for a command line option from the settings. Could you point me to a good example?

Potential future improvement: add the `format` and `tformat` options and a text field so users can enter their own. From [Git docs here](https://git-scm.com/docs/git-show) (search for "format:<string>")
