### PR TITLE
Fix #533

### DIFF
--- a/lib/grammars/diff.js
+++ b/lib/grammars/diff.js
@@ -96,7 +96,7 @@
 			removedResult = grammar.tokenizeLine(removedLine, codeStack);
 			removedIdx = removedLine.length;
 		}
-		if (addedLine && addedLine.trim().length) {
+		if (addedLine && addedLine.trim().length !== undefined) {
 			addedResult = grammar.tokenizeLine(addedLine, codeStack);
 			addedIdx = addedLine.length;
 		}

--- a/lib/grammars/diff.json
+++ b/lib/grammars/diff.json
@@ -138,5 +138,5 @@
 		},
 		"contentName": "markup.added.diff"
 	}],
-	"scopeName": "diff"
+	"scopeName": "source.diff"
 }


### PR DESCRIPTION
@sharedprophet In diff.json, I changed "scopeName" back to 'source.diff'. This enables atom's language-git highlighting of diffs in commit files.

The change on line 99 of diff.js fixes an issue I found when `addedLine.trim()` is an empty string and length is `0` and `0 == false` unfortunately.

I've done some other poking around and it seems like all the other diff highlighting still works fine.