### PR TITLE
Add checkout shortcut

### DIFF
--- a/keymaps/git-plus.cson
+++ b/keymaps/git-plus.cson
@@ -10,7 +10,8 @@
 
 '.platform-darwin':
   'cmd-shift-h': 'git-plus:menu'
-  'cmd-shift-c': 'git-plus:commit'
+  'cmd-shift-x': 'git-plus:commit'
+  'cmd-shift-c': 'git-plus:checkout'
   'cmd-shift-a s': 'git-plus:status'
   'cmd-shift-a q': 'git-plus:add-and-commit-and-push'
   'cmd-shift-a a': 'git-plus:add-all-and-commit'
@@ -19,6 +20,7 @@
 '.platform-win32, .platform-linux':
   'ctrl-shift-h': 'git-plus:menu'
   'ctrl-shift-x': 'git-plus:commit'
+  'ctrl-shift-c': 'git-plus:checkout'
   'ctrl-shift-a s': 'git-plus:status'
   'ctrl-shift-a q': 'git-plus:add-and-commit-and-push'
   'ctrl-shift-a a': 'git-plus:add-all-and-commit'


### PR DESCRIPTION
Checking out is one of the most used features IMHO.

Adding key for that. To fix conflict in :apple:, make it behave as normal humans and commit with `x`.

Have you looked at the [guidelines](https://github.com/akonwi/git-plus/blob/master/.github/CONTRIBUTING.md) for contributing to this codebase?
Have you added tests and run `apm test`?
