### PR TITLE
fix checkout remote branch

### DIFF
--- a/lib/models/git-checkout-branch.js
+++ b/lib/models/git-checkout-branch.js
@@ -11,7 +11,8 @@ module.exports = (repo, options={remote: false}) => {
   .then(data => {
     return new BranchListView(data, ({name}) => {
       const branch = name
-      git.cmd(['checkout'].concat(branch), {cwd: repo.getWorkingDirectory()})
+      const args = options.remote ? ['checkout', '--track'] : ['checkout']
+      git.cmd(args.concat(branch), {cwd: repo.getWorkingDirectory()})
       .then(message => {
         notifier.addSuccess(message)
         atom.workspace.getTextEditors().forEach(editor => {


### PR DESCRIPTION
**Expected behavior**:
- Call command "git-plus:checkout-remote"
- Command "git-plus:checkout-remote" calls `git checkout --track original/some-branch`
- The git branch changed to `some-branch`

**Actual behavior**: 
- Call command "git-plus:checkout-remote"
- Command "git-plus:checkout-remote" calls `git checkout original/some-branch`
- The git in that case changes to 'detached HEAD' state and makes checkout to the HEAD of `some-branch`

