### PR TITLE
support right click git root path

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -138,7 +138,7 @@ module.exports = git =
 
         Promise.all(repoPromises).then (repos) ->
           repos.forEach (repo) ->
-            if repo? and (new Directory(repo.getWorkingDirectory())).contains path
+            if repo? and ((new Directory(repo.getWorkingDirectory())).contains path) or ((new Directory(repo.getWorkingDirectory())).getPath() == path)
               submodule = repo?.repo.submoduleForPath(path)
               if submodule? then resolve(submodule) else resolve(repo)
 


### PR DESCRIPTION
I think should allow people to right click git root path  to run some git command. Currently, git-plus does nothing,when right click git root path in tree-view.

Have you looked at the [guidelines](https://github.com/akonwi/git-plus/blob/master/.github/CONTRIBUTING.md) for contributing to this codebase?
Have you added tests and run `apm test`?
