### PR TITLE
Allowing GPG signing of Git tags

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -159,3 +159,9 @@ module.exports =
         type: "boolean"
         default: false
         description: "Show notifications while running `fetch --all`?"
+      signTags:
+        order: 7
+        title: "Sign git tags with GPG"
+        type: "boolean"
+        default: false
+        description: "Use a GPG key to sign Git tags"

--- a/lib/views/tag-create-view.coffee
+++ b/lib/views/tag-create-view.coffee
@@ -32,7 +32,8 @@ class TagCreateView extends View
 
   createTag: ->
     tag = name: @tagName.getModel().getText(), message: @tagMessage.getModel().getText()
-    git.cmd(['tag', '-a', tag.name, '-m', tag.message], cwd: @repo.getWorkingDirectory())
+    flag = if atom.config.get('git-plus.experimental.signTags') then '-s' else '-a'
+    git.cmd(['tag', flag, tag.name, '-m', tag.message], cwd: @repo.getWorkingDirectory())
     .then (success) ->
       notifier.addSuccess("Tag '#{tag.name}' has been created successfully!") if success
     .catch (msg) ->

--- a/spec/views/tag-create-view-spec.coffee
+++ b/spec/views/tag-create-view-spec.coffee
@@ -18,3 +18,12 @@ describe "TagCreateView", ->
       @view.tagMessage.setText 'tag1 message'
       @view.find('.gp-confirm-button').click()
       expect(git.cmd).toHaveBeenCalledWith ['tag', '-a', 'tag1', '-m', 'tag1 message'], {cwd}
+
+    it "creates a signed tag with the given name and message", ->
+      atom.config.set('git-plus.experimental.signTags', true)
+      spyOn(git, 'cmd').andReturn Promise.resolve 0
+      cwd = repo.getWorkingDirectory()
+      @view.tagName.setText 'tag2'
+      @view.tagMessage.setText 'tag2 message'
+      @view.find('.gp-confirm-button').click()
+      expect(git.cmd).toHaveBeenCalledWith ['tag', '-s', 'tag2', '-m', 'tag2 message'], {cwd}


### PR DESCRIPTION
Not a huge change, but my first modification to an Atom package, so I would encourage a careful review. Added a config boolean (and a test to cover it). Defaults to previous behavior. Really just changes `tag -a` to `tag -s` if the `signTags` boolean is `true`.

Without this, I don't get the pretty "Verified" text next to my tags in GitHub.