### PR TITLE
Keep the installed source.diff grammar

### DIFF
--- a/lib/git-plus.coffee
+++ b/lib/git-plus.coffee
@@ -61,9 +61,6 @@ currentFile = (repo) ->
   repo.relativize(atom.workspace.getActiveTextEditor()?.getPath())
 
 setDiffGrammar = ->
-  while atom.grammars.grammarForScopeName 'source.diff'
-    atom.grammars.removeGrammarForScopeName 'source.diff'
-
   enableSyntaxHighlighting = atom.config.get('git-plus.diffs.syntaxHighlighting')
   wordDiff = atom.config.get('git-plus.diffs.wordDiff')
   diffGrammar = null
@@ -77,11 +74,9 @@ setDiffGrammar = ->
     baseGrammar = baseLineGrammar
 
   if enableSyntaxHighlighting
+    while atom.grammars.grammarForScopeName 'source.diff'
+      atom.grammars.removeGrammarForScopeName 'source.diff'
     atom.grammars.addGrammar diffGrammar
-  else
-    grammar = atom.grammars.readGrammarSync baseGrammar
-    grammar.packageName = 'git-plus'
-    atom.grammars.addGrammar grammar
 
 getWorkspaceRepos = -> atom.project.getRepositories().filter (r) -> r?
 


### PR DESCRIPTION
this PR is a fix for #646 

disable `syntaxHighlighting` in settings and restart atom.

after atom is restarted, open the developer tools and run the following
code inside the console.

```javascript
var XXX_get = function() {
  return atom.grammars.grammarForScopeName('source.diff')
};
var XXX_say = function() {
  var g = XXX_get();
  console.log('name:%s, package:%s, path:%s',
    g.name, g.packageName, g.path);
};
XXX_say()
```

the expected output is as follows:

```
name:Diff, package:language-diff,
  path:~/.atom/packages/language-diff/grammars/diff.cson
```

now open a new empty file and run `XXX_say()` in the console. the output
should be the same as in first run. next open the grammar selector and
type `diff` but do not yet change the grammar! there should be two
entries in the selector. `Diff` and `Line Diff`. `Diff` is from
`language-diff` and `Line Diff` is from `git-plus`. change into the
console and run `XXX_say()` again. as before, the output is correct. now
change the grammar and check the console. output should as expected. the
grammar is now `Diff`, the file is still empty and unsaved. save the
empty file somewhere and watch the grammar indicator inside the status
bar. immediately after save the grammar automatically changes to
`Line Diff` and i got this as output in the console

```
name:Line Diff, package:git-plus,
  path:~/.atom/packages/git-plus/lib/grammars/line-diff.json
```

run `XXX_get()` to dump the entire `Grammar` object.

the grammar selector now has two `Line Diff` entries.

maybe the problem is the `onPathsChanged()` callback function. after
saving the file, atom opens the `tree view` with the directory of the
file as root. `onPathsChanged()` calls `@deactivate()` and
`@activate()`. `@activate()` calls `setDiffGrammar()` which removes all
grammars for `source.diff` and enables his own `Line Diff` grammar if
`syntaxHighlighting` is disabled.

this patch moves the code that removes the grammars some lines down into
the if condition where the new grammar is added. the else condition to
reload the grammar is not longer needed. because nothing is removed if
`syntaxHighlighting` is not enabled.

works for me (atom is packaged from copr
[mosquito/atom](https://copr.fedorainfracloud.org/coprs/mosquito/atom/))

`apm list -b | grep -e language-diff -e git-plus`

> git-plus@7.3.3
> language-diff@0.7.0

`atom --version`

> Atom    : 1.15.0
> Electron: 1.3.13
> Chrome  : 52.0.2743.82
> Node    : 6.5.0

`lsb_release -s -d`

> "Fedora release 25 (Twenty Five)"