### PR TITLE
opend projects not all git repo,git-plus Invalid

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -143,6 +143,9 @@ module.exports = git =
 
         Promise.all(repoPromises).then (repos) ->
           repos.forEach (repo) ->
+            if not repo?
+              return
+            
             directory = new Directory(repo.getWorkingDirectory())
             if repo? and directory.contains(path) or directory.getPath() is path
               submodule = repo?.repo.submoduleForPath(path)


### PR DESCRIPTION
RepoA is a SVN repo; RepoB is a GIT repo. open RepoA,and then open RepoB. Now,git-plus will be Invalid on RepoB!

Have you looked at the [guidelines](https://github.com/akonwi/git-plus/blob/master/.github/CONTRIBUTING.md) for contributing to this codebase?
Have you added tests and run `apm test`?
