### PR TITLE
Amend complex commits

### DIFF
--- a/spec/models/git-commit-amend-spec.coffee
+++ b/spec/models/git-commit-amend-spec.coffee
@@ -75,3 +75,83 @@ describe "GitCommitAmendShort", ->
     textEditor.destroy()
     expect(currentPane.activate).toHaveBeenCalled()
     expect(fs.unlink).toHaveBeenCalledWith commitFilePath
+
+describe "GitCommitAmendLong", ->
+  beforeEach ->
+    spyOn(atom.workspace, 'getActivePane').andReturn currentPane
+    spyOn(atom.workspace, 'open').andReturn Promise.resolve textEditor
+    spyOn(atom.workspace, 'getPanes').andReturn [currentPane, commitPane]
+    spyOn(atom.workspace, 'paneForURI').andReturn commitPane
+    spyOn(git, 'refresh')
+
+    spyOn(commitPane, 'destroy').andCallThrough()
+    spyOn(currentPane, 'activate')
+
+    spyOn(fs, 'unlink')
+    spyOn(fs, 'readFileSync').andReturn ''
+    spyOn(git, 'stagedFiles').andCallFake ->
+      args = git.stagedFiles.mostRecentCall.args
+      if args[0].getWorkingDirectory() is repo.getWorkingDirectory()
+        Promise.resolve [pathToRepoFile]
+
+    spyOn(git, 'cmd').andCallFake ->
+      args = git.cmd.mostRecentCall.args[0]
+      switch args[0]
+        when 'whatchanged' then Promise.resolve """This is a long commit
+        Commit title
+
+        body line 1
+        body line 2
+          ‐body line 3
+        body line 4
+
+
+        :100644 100644 a309cc9... b46b93c... M package.json
+        :100644 100644 a309cc9... b46b93c...   sys.conf
+        :100644 100644 a309cc9... b46b93c... A new.conf
+        :100644 100644 a309cc9... b46b93c... D old.conf
+        :100644 100644 a309cc9... b46b93c... R ren.conf
+        :100644 100644 a309cc9... b46b93c... C euque.conf
+        :100644 100644 a309cc9... b46b93c... U unk.conf
+        :100644 100644 a309cc9... b46b93c... ? quest.conf
+        :100644 100644 a309cc9... b46b93c... ! imp.conf"""
+        when 'status' then Promise.resolve 'current status'
+        else Promise.resolve ''
+
+  it "gets the previous commit message and changed files", ->
+    expectedGitArgs = ['whatchanged', '-1', '--format=%B']
+    GitCommitAmend repo
+    expect(git.cmd).toHaveBeenCalledWith expectedGitArgs, cwd: repo.getWorkingDirectory()
+
+  it "writes to the new commit file", ->
+    spyOn(fs, 'writeFileSync')
+    GitCommitAmend repo
+    waitsFor ->
+      fs.writeFileSync.callCount > 0
+    runs ->
+      actualPath = fs.writeFileSync.mostRecentCall.args[0]
+      expect(actualPath).toEqual commitFilePath
+
+  xit "shows the file", ->
+    GitCommitAmend repo
+    waitsFor ->
+      atom.workspace.open.callCount > 0
+    runs ->
+      expect(atom.workspace.open).toHaveBeenCalled()
+
+  xit "calls git.cmd with ['commit'...] on textEditor save", ->
+    GitCommitAmend repo
+    textEditor.save()
+    expect(git.cmd).toHaveBeenCalledWith ['commit', '--amend', '--cleanup=strip', "--file=#{commitFilePath}"], cwd: repo.getWorkingDirectory()
+
+  xit "closes the commit pane when commit is successful", ->
+    GitCommitAmend repo
+    textEditor.save()
+    waitsFor -> commitPane.destroy.callCount > 0
+    runs -> expect(commitPane.destroy).toHaveBeenCalled()
+
+  xit "cancels the commit on textEditor destroy", ->
+    GitCommitAmend repo
+    textEditor.destroy()
+    expect(currentPane.activate).toHaveBeenCalled()
+    expect(fs.unlink).toHaveBeenCalledWith commitFilePath

--- a/spec/models/git-commit-amend-spec.coffee
+++ b/spec/models/git-commit-amend-spec.coffee
@@ -13,7 +13,7 @@ GitCommitAmend = require '../../lib/models/git-commit-amend'
 
 commitFilePath = Path.join(repo.getPath(), 'COMMIT_EDITMSG')
 
-describe "GitCommitAmend", ->
+describe "GitCommitAmendShort", ->
   beforeEach ->
     spyOn(atom.workspace, 'getActivePane').andReturn currentPane
     spyOn(atom.workspace, 'open').andReturn Promise.resolve textEditor
@@ -39,7 +39,7 @@ describe "GitCommitAmend", ->
         else Promise.resolve ''
 
   it "gets the previous commit message and changed files", ->
-    expectedGitArgs = ['whatchanged', '-1', '--name-status', '--format=%B']
+    expectedGitArgs = ['whatchanged', '-1', '--format=%B']
     GitCommitAmend repo
     expect(git.cmd).toHaveBeenCalledWith expectedGitArgs, cwd: repo.getWorkingDirectory()
 


### PR DESCRIPTION
Solving the bug from issue #681 and #710

Sadly I didn't found any way to create a complete test for this function
I added a full test of the Commit Amend with a complex commit message, but I can see how some changes in the future might break the function without breaking the tests

Actually the original code have exactly the same problem, the tests cannot validate the return of the 'parse' function because it's private to the 'git-commit-amend' file
So if some future changes breaks the return to another valid return, but not the correct one (maybe missing one of the previous modifications), the tests will still pass