### PR TITLE
Fix #717 (registry.startIdForScope is not a function)

### DIFF
--- a/lib/grammars/diff.js
+++ b/lib/grammars/diff.js
@@ -127,7 +127,7 @@
         for (let j = 0; j < codeStack.length; j++) {
           var scope = codeStack[j].scopeName || codeStack[j].contentScopeName
           if (scope) {
-            tagStack.push(atom.grammars.textmateRegistry.startIdForScope(scope))
+            tagStack.push((atom.grammars.textmateRegistry || atom.grammars.registry).startIdForScope(scope))
           }
         }
       }


### PR DESCRIPTION
This fix is straightforward and simply implements the same solution used for digitallyserviced/semanticolor#27.