### PR TITLE
Add option to always open bottom dock with result

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -50,6 +50,12 @@ module.exports =
         default: "full"
         enum: ["oneline", "short", "medium", "full", "fuller", "email", "raw", "none"]
         description: "Which format to use for `git show`? (`none` will use your git config default)"
+      alwaysOpenDockWithResult:
+        order: 7
+        title: "Always show result output"
+        type: "boolean"
+        default: false
+        description: "Always display bottom dock with output after command is complete (regardless of dock visibility)"
   commits:
     order: 2
     type: "object"

--- a/lib/views/output-view.js
+++ b/lib/views/output-view.js
@@ -22,7 +22,7 @@ class OutputView {
   }
 
   show() {
-    if (!this.isVisible) {
+    if (!this.isVisible || atom.config.get('git-plus.general.alwaysOpenDockWithResult')) {
       atom.workspace.open(this).then(() => {
         this.isVisible = true
         atom.workspace.getBottomDock().show()


### PR DESCRIPTION
Added an option to always open bottom dock with the result of the command, regardless of bottom dock visibility.
