### PR TITLE
WIP: Fixes #787 not to restore output view when without serialized view

### DIFF
--- a/lib/git-plus.js
+++ b/lib/git-plus.js
@@ -87,7 +87,6 @@ module.exports = {
   activate(_state) {
     setDiffGrammar();
     const repos = getWorkspaceRepos();
-    if (this.outputView === null) this.outputView = new OutputViewContainer();
 
     atom.workspace.addOpener(uri => {
       if (uri === OutputViewContainer.URI) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,14 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-dom": {
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.4.tgz",
+      "integrity": "sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "acorn": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
@@ -557,7 +565,6 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -568,7 +575,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -2080,8 +2086,7 @@
         "longest": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "optional": true
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
         },
         "loud-rejection": {
           "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@babel/polyfill": "^7.0.0-beta.51",
     "@types/atom": "^1.31.0",
     "@types/react": "^16.7.13",
+    "@types/react-dom": "^16.8.4",
     "ansi-to-html": "^0.4.1",
     "atom-babel6-transpiler": "^1.2.0",
     "atom-notify": "^1.1.0",


### PR DESCRIPTION
In this PR, I'm trying to address the problem proposed in #787.

### What's wrong

So far, I confirmed that when there is a previously _serialized_ view, `deserializedOutputView` works fine and restores the view into the location where it located.

But even when the view had been destroyed, `activate` function still creates a new `OutputViewContainer` object anyway, and the pane is even _toggled_ because it's defined in the constructor, which makes this problem.

### Workaround

I deleted the line in `activate` function and the annoying restoring _seems_ disappeared 👇 

### Why WIP ? (Remaining work)

The remaining problem now is that when we don't have a restored output view and then call `git-plus:run`, we have to manually create the view by invoking `git-plus:toggle-output-view` in order to see the result, since there is no view yet.

I think it's better to create (and toggle) the view when we first call `git-plus:run` by checking if there is an already existing view.
But I'm not sure `git-plus:run` is the only user command which uses `OutputViewComponent`, thus I leave this PR WIP.

So, could you tell me all the cases when we use `OutputViewComponent` ??
Or does this workaround seem inappropriate this time ?