### PR TITLE
Fix display name of `Fetch-All (Repos & Remotes)` command

### DIFF
--- a/lib/git-plus.js
+++ b/lib/git-plus.js
@@ -204,7 +204,7 @@ module.exports = {
       );
       this.subscriptions.add(
         atom.commands.add("atom-workspace", "git-plus:fetch-all", {
-          displayName: "Fetch All (Repos & Remotes)",
+          displayName: "Git-Plus: Fetch All (Repos & Remotes)",
           didDispatch: _event => gitFetchInAllRepos()
         })
       );


### PR DESCRIPTION
The command's display name for command pallet is just `Fetch-All (Repos & Remotes)` and it appears kinda weird and inconsistent because it lacks the package name prefix.